### PR TITLE
[Round 03] - 기능 구현

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandApplicationService.java
@@ -5,6 +5,7 @@ import com.loopers.domain.brand.BrandService;
 import com.loopers.interfaces.api.controller.brand.BrandResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class BrandApplicationService implements BrandUsecase {
     private final BrandService brandService;
 
     @Override
+    @Transactional(readOnly = true)
     public BrandResponse getBrandInfo(Long brandId) {
         Brand brand = brandService.get(brandId);
         return BrandResponse.from(brand);

--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandApplicationService.java
@@ -2,7 +2,7 @@ package com.loopers.application.brand;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
-import com.loopers.interfaces.api.controller.brand.BrandResponse;
+import com.loopers.interfaces.api.controller.brand.BrandV1Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +15,8 @@ public class BrandApplicationService implements BrandUsecase {
 
     @Override
     @Transactional(readOnly = true)
-    public BrandResponse getBrandInfo(Long brandId) {
+    public BrandV1Response getBrandInfo(Long brandId) {
         Brand brand = brandService.get(brandId);
-        return BrandResponse.from(brand);
+        return BrandV1Response.from(brand);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandApplicationService.java
@@ -1,0 +1,20 @@
+package com.loopers.application.brand;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.interfaces.api.controller.brand.BrandResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BrandApplicationService implements BrandUsecase {
+
+    private final BrandService brandService;
+
+    @Override
+    public BrandResponse getBrandInfo(Long brandId) {
+        Brand brand = brandService.get(brandId);
+        return BrandResponse.from(brand);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandUsecase.java
@@ -1,0 +1,7 @@
+package com.loopers.application.brand;
+
+import com.loopers.interfaces.api.controller.brand.BrandResponse;
+
+public interface BrandUsecase {
+    BrandResponse getBrandInfo(Long brandId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/brand/BrandUsecase.java
@@ -1,7 +1,7 @@
 package com.loopers.application.brand;
 
-import com.loopers.interfaces.api.controller.brand.BrandResponse;
+import com.loopers.interfaces.api.controller.brand.BrandV1Response;
 
 public interface BrandUsecase {
-    BrandResponse getBrandInfo(Long brandId);
+    BrandV1Response getBrandInfo(Long brandId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeApplicationService.java
@@ -6,12 +6,13 @@ import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @RequiredArgsConstructor
-@Service
+@Component
 public class LikeApplicationService implements LikeUsecase {
 
     private final UserService userService;
@@ -20,6 +21,7 @@ public class LikeApplicationService implements LikeUsecase {
     private final ProductService productService;
 
     @Override
+    @Transactional
     public void like(LikeCommand.Like command) {
         User user = userService.getUser(command.loginId());
         Product product = productService.getProduct(command.targetId());
@@ -28,14 +30,16 @@ public class LikeApplicationService implements LikeUsecase {
     }
 
     @Override
+    @Transactional
     public void unlike(LikeCommand.Like command) {
         User user = userService.getUser(command.loginId());
         Product product = productService.getProduct(command.targetId());
-        likeValidator.validateExists(user.getId(), product.getId(), command.targetType()); // 그 좋아요가 이미 잇는지 확인 (잇어야 삭제가능)
+        likeValidator.validateExists(user.getId(), product.getId(), command.targetType());
         likeService.delete(user.getId(), product.getId(), command.targetType());
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<LikeInfo.LikedProduct> getLikedProducts(LikeCommand.LikedProducts command) {
 
         User user = userService.getUser(command.loginId());

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeApplicationService.java
@@ -1,0 +1,64 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.*;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class LikeApplicationService implements LikeUsecase {
+
+    private final UserService userService;
+    private final LikeValidator likeValidator;
+    private final LikeService likeService;
+    private final ProductService productService;
+
+    @Override
+    public void like(LikeCommand.Like command) {
+        User user = userService.getUser(command.loginId());
+        Product product = productService.getProduct(command.targetId());
+        likeValidator.validateNotExists(user.getId(), product.getId(), command.targetType());
+        likeService.save(user.getId(), product.getId(), command.targetType());
+    }
+
+    @Override
+    public void unlike(LikeCommand.Like command) {
+        User user = userService.getUser(command.loginId());
+        Product product = productService.getProduct(command.targetId());
+        likeValidator.validateExists(user.getId(), product.getId(), command.targetType()); // 그 좋아요가 이미 잇는지 확인 (잇어야 삭제가능)
+        likeService.delete(user.getId(), product.getId(), command.targetType());
+    }
+
+    @Override
+    public List<LikeInfo.LikedProduct> getLikedProducts(LikeCommand.LikedProducts command) {
+
+        User user = userService.getUser(command.loginId());
+
+        List<LikedProduct> infos = likeService.getLikedProducts(
+                user.getId(),
+                command.page(),
+                command.size()
+        );
+
+        return infos.stream()
+                .map(p -> new LikeInfo.LikedProduct(
+                        p.id(),
+                        p.name(),
+                        p.price(),
+                        p.likeCount(),
+                        p.status(),
+                        p.createdAt()
+                ))
+                .toList();
+    }
+
+
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUsecase.java
@@ -1,0 +1,12 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.LikeCommand;
+import com.loopers.domain.like.LikeInfo;
+
+import java.util.List;
+
+public interface LikeUsecase {
+    void like(LikeCommand.Like command);
+    void unlike(LikeCommand.Like command);
+    List<LikeInfo.LikedProduct> getLikedProducts(LikeCommand.LikedProducts command);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUsecase.java
@@ -6,7 +6,7 @@ import com.loopers.domain.like.LikeInfo;
 import java.util.List;
 
 public interface LikeUsecase {
-    void like(LikeCommand.Like command);
+    LikeInfo.Like like(LikeCommand.Like command);
     void unlike(LikeCommand.Like command);
     List<LikeInfo.LikedProduct> getLikedProducts(LikeCommand.LikedProducts command);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-@Transactional
 public class OrderApplicationService implements OrderUsecase {
 
     private final UserService userService;
@@ -24,6 +23,7 @@ public class OrderApplicationService implements OrderUsecase {
     private final OrderService orderService;
 
     @Override
+    @Transactional
     public OrderInfo.CreateOrder order(OrderCommand.CreateOrder command) {
 
         User user = userService.getUser(command.loginId());
@@ -50,6 +50,7 @@ public class OrderApplicationService implements OrderUsecase {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<OrderInfo.OrderListItem> getOrdersByUserId(String loginId) {
         // 사용자조회
         User user = userService.getUser(loginId);
@@ -61,6 +62,7 @@ public class OrderApplicationService implements OrderUsecase {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public OrderInfo.OrderDetail getOrderDetail(Long orderId) {
         Order order = orderService.getOrder(orderId);
         return OrderInfo.OrderDetail.from(order);

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
@@ -1,0 +1,68 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.*;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class OrderApplicationService implements OrderUsecase {
+
+    private final UserService userService;
+    private final ProductSkuService productSkuService;
+    private final ProductService productService;
+    private final OrderService orderService;
+
+    @Override
+    public OrderInfo.CreateOrder order(OrderCommand.CreateOrder command) {
+
+        User user = userService.getUser(command.loginId());
+        Order order = Order.create(user.getId(), 0L);
+
+        // 주문항목 처리
+        command.items().forEach(item -> {
+            // 재고조회
+            ProductSku sku = productSkuService.getBySkuId(item.productSkuId());
+            // 재고선점
+            productSkuService.reserveStock(sku, item.quantity());
+            //관련상품의 모든 옵션애 대해 재고 판단.
+            boolean isAllSoldOut = productSkuService.isAllSoldOut(sku.getProduct().getId());
+            //isAllSoldOut == true 라면 상태값바꿈
+            productService.updateStatus(isAllSoldOut,sku.getProduct().getId());
+            // 가격합산
+            order.addPrice((long) (sku.getPrice() * item.quantity()));
+            // 주문항목 추가
+            order.addOrderItem(OrderItem.create(sku.getId(), item.quantity()));
+        });
+
+        Order savedOrder = orderService.saveOrder(order);
+        return OrderInfo.CreateOrder.from(savedOrder);
+    }
+
+    @Override
+    public List<OrderInfo.OrderListItem> getOrdersByUserId(String loginId) {
+        // 사용자조회
+        User user = userService.getUser(loginId);
+
+        return orderService.getOrdersByUserId(user.getId())
+                .stream()
+                .map(OrderInfo.OrderListItem::from)
+                .toList();
+    }
+
+    @Override
+    public OrderInfo.OrderDetail getOrderDetail(Long orderId) {
+        Order order = orderService.getOrder(orderId);
+        return OrderInfo.OrderDetail.from(order);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUsecase.java
@@ -9,4 +9,5 @@ public interface OrderUsecase {
     OrderInfo.CreateOrder order(OrderCommand.CreateOrder command);
     List<OrderInfo.OrderListItem> getOrdersByUserId(String loginId);
     OrderInfo.OrderDetail getOrderDetail(Long orderId);
+    OrderInfo.CancelOrder cancelOrder(OrderCommand.CancelOrder command);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUsecase.java
@@ -1,0 +1,12 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.order.OrderInfo;
+
+import java.util.List;
+
+public interface OrderUsecase {
+    OrderInfo.CreateOrder order(OrderCommand.CreateOrder command);
+    List<OrderInfo.OrderListItem> getOrdersByUserId(String loginId);
+    OrderInfo.OrderDetail getOrderDetail(Long orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
@@ -6,11 +6,13 @@ import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentCommand;
 import com.loopers.domain.payment.PaymentInfo;
 import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.ProductSkuService;
 import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserCommand;
 import com.loopers.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
@@ -20,6 +22,8 @@ public class PaymentApplicationService implements PaymentUsecase {
     private final UserService userService;
     private final OrderService orderService;
     private final PaymentService paymentService;
+    private final ProductSkuService productSkuService;
+    private final ProductService productService;
 
     @Override
     @Transactional
@@ -44,4 +48,35 @@ public class PaymentApplicationService implements PaymentUsecase {
 
         return PaymentInfo.CreatePayment.from(saved);
     }
+
+    @Override
+    @Transactional
+    public PaymentInfo.CancelPayment cancelPayment(PaymentCommand.CancelPayment command) {
+        // 사용자 조회
+        User user = userService.getUser(command.loginId());
+        // 결제 조회
+        Payment payment = paymentService.getPayment(command.paymentId());
+        // 취소 가능 여부 검증
+        paymentService.validateCancelable(payment,user);
+        // 결제수단별 복구 처리
+        if (payment.getMethod() == Payment.Method.POINT) {
+            UserCommand.Charge chargeCommand  = new UserCommand.Charge(command.loginId(), payment.getAmount());
+            userService.charge(chargeCommand);
+        }
+        // 주문 조회
+        Order order = orderService.getOrder(command.orderId());
+        // 취소 가능 여부 검증
+        orderService.validateCancelable(order,user);
+        // 재고 복구
+        order.getOrderItems().forEach(item ->
+                productSkuService.rollbackReservedStock(item.getProductSkuId(), item.getQuantity())
+        );
+        // 주문 상태 변경 및 저장
+        orderService.cancelOrder(order);
+        // 결제 취소
+        paymentService.cancelPayment(payment);
+
+        return PaymentInfo.CancelPayment.from(payment);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
@@ -1,0 +1,44 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.payment.PaymentInfo;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentApplicationService implements PaymentUsecase {
+
+    private final UserService userService;
+    private final OrderService orderService;
+    private final PaymentService paymentService;
+
+    @Override
+    public PaymentInfo.CreatePayment createPayment(PaymentCommand.CreatePayment command) {
+        //사용자 조회
+        User user = userService.getUser(command.loginId());
+        // 주문 조회 및 상태 확인
+        Order order = orderService.getOrder(command.orderId());
+        order.isConfirmed();
+        //결제 생성
+        Payment payment = Payment.create(
+                user.getId(),
+                order.getId(),
+                command.amount(),
+                Payment.Method.valueOf(command.method())
+        );
+        // 저장
+        Payment saved = paymentService.save(payment);
+        //주문 상태 변경
+        order.confirm();
+        orderService.saveOrder(order);
+
+        return PaymentInfo.CreatePayment.from(saved);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
@@ -9,9 +9,11 @@ import com.loopers.domain.payment.PaymentService;
 import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class PaymentApplicationService implements PaymentUsecase {
 
@@ -20,6 +22,7 @@ public class PaymentApplicationService implements PaymentUsecase {
     private final PaymentService paymentService;
 
     @Override
+    @Transactional
     public PaymentInfo.CreatePayment createPayment(PaymentCommand.CreatePayment command) {
         //사용자 조회
         User user = userService.getUser(command.loginId());

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUsecase.java
@@ -1,0 +1,8 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.payment.PaymentInfo;
+
+public interface PaymentUsecase {
+    PaymentInfo.CreatePayment createPayment(PaymentCommand.CreatePayment command);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUsecase.java
@@ -5,4 +5,6 @@ import com.loopers.domain.payment.PaymentInfo;
 
 public interface PaymentUsecase {
     PaymentInfo.CreatePayment createPayment(PaymentCommand.CreatePayment command);
+    PaymentInfo.CancelPayment cancelPayment(PaymentCommand.CancelPayment command);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -6,6 +6,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
@@ -17,6 +18,7 @@ public class PointFacade {
         return userService.charge(command);
     }
 
+    @Transactional
     public UserInfo.Point myPoint(String loginId){
         UserInfo.Point userPoint = userService.myPoint(loginId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
@@ -1,0 +1,45 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.like.LikeTargetType;
+import com.loopers.domain.product.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProductApplicationService implements ProductUsecase {
+
+    private final ProductService productService;
+    private final ProductSkuService productSkuService;
+    private final LikeService likeService;
+    private final BrandService brandService;
+
+    @Override
+    public List<ProductInfo.Summary> getProductSummaries(ProductCommand.List command) {
+        return productService.getProductSummaries(command).stream()
+                .map(ProductInfo.Summary::from)
+                .toList();
+    }
+
+    @Override
+    public ProductInfo.Detail getProductDetail(Long productId) {
+        // 상품정보조회
+        Product product = productService.getProduct(productId);
+        // 상품 옵션별재고 조회
+        List<ProductSku> skus = productSkuService.getByProductId(productId);
+        // 좋아요 개수 조회
+        long likeCount = likeService.getLikeCount(productId, LikeTargetType.PRODUCT);
+        // 브랜드 정보 조회
+        String brandName = brandService.get(product.getBrandId()).getName();
+
+        return ProductInfo.Detail.from(product, brandName, skus, likeCount);
+    }
+
+}
+
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
@@ -6,6 +6,7 @@ import com.loopers.domain.like.LikeTargetType;
 import com.loopers.domain.product.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -19,6 +20,7 @@ public class ProductApplicationService implements ProductUsecase {
     private final BrandService brandService;
 
     @Override
+    @Transactional(readOnly = true)
     public List<ProductInfo.Summary> getProductSummaries(ProductCommand.List command) {
         return productService.getProductSummaries(command).stream()
                 .map(ProductInfo.Summary::from)
@@ -26,6 +28,7 @@ public class ProductApplicationService implements ProductUsecase {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ProductInfo.Detail getProductDetail(Long productId) {
         // 상품정보조회
         Product product = productService.getProduct(productId);

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductUsecase.java
@@ -1,0 +1,13 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.ProductCommand;
+import com.loopers.domain.product.ProductInfo;
+
+import java.util.List;
+
+public interface ProductUsecase {
+    List<ProductInfo.Summary> getProductSummaries(ProductCommand.List command);
+    ProductInfo.Detail getProductDetail(Long productId);
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserUsecase.java
@@ -1,0 +1,4 @@
+package com.loopers.application.user;
+
+public interface UserUsecase {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/Brand.java
@@ -1,0 +1,49 @@
+package com.loopers.domain.brand;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "brand")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Brand extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = true)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status;
+
+    public enum Status {
+        ACTIVE,     // 조회 가능
+        INACTIVE    // 조회 불가
+    }
+
+    public void deactivate() {
+        this.status = Status.INACTIVE;
+    }
+
+    public boolean isActive() {
+        return this.status == Status.ACTIVE;
+    }
+
+    public static Brand create(String name, String description) {
+        return Brand.builder()
+                .name(name)
+                .description(description)
+                .status(Status.ACTIVE)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandInfo.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.brand;
+
+public record BrandInfo(
+        Long id,
+        String name
+) {
+    public static BrandInfo from(Brand brand) {
+        return new BrandInfo(brand.getId(), brand.getName());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.brand;
+
+import java.util.Optional;
+
+public interface BrandRepository {
+    Optional<Brand> findById(long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandService.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.brand;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BrandService {
+
+    private final BrandRepository brandRepository;
+
+    public Brand get(Long brandId) {
+        Brand brand = brandRepository.findById(brandId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 브랜드입니다.")); ;
+
+        if (!brand.isActive()) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"비활성화된 브랜드입니다.");
+        }
+        return brand;
+    }
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/Like.java
@@ -1,0 +1,47 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "likes", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "target_id", "target_type"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Like extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private LikeTargetType  targetType;
+
+    public static Like create(Long userId, Long targetId, LikeTargetType targetType) {
+        return Like.builder()
+                .userId(userId)
+                .targetId(targetId)
+                .targetType(targetType)
+                .build();
+    }
+
+    public boolean isTargetOf(Long id, LikeTargetType type) {
+        return this.targetId.equals(id) && this.targetType == type;
+    }
+
+    public boolean isSameUser(User user) {
+        return this.userId.equals(user.getId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeCommand.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.like;
+
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class LikeCommand{
+
+    public record Like(
+            String loginId,
+            Long targetId,
+            LikeTargetType targetType
+    ) {
+
+        public static LikeCommand.Like of(String loginId, Long targetId, LikeTargetType targetType) {
+            return new LikeCommand.Like(loginId, targetId, targetType);
+        }
+    }
+
+    public record LikedProducts (
+            String loginId,
+            LikeTargetType targetType,
+            int page,
+            int size
+    ){
+        public Pageable toPageable() {
+            return PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        }
+        public int offset() {
+            return page * size;
+        }
+    }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeInfo.java
@@ -13,15 +13,14 @@ public class LikeInfo {
             Product.Status status,
             LocalDateTime createdAt
     ) {
-//        public static LikeInfo.LikedProduct from(LikedProduct product) {
-//            return new LikeInfo.LikedProduct(
-//                    product.id(),
-//                    product.name(),
-//                    product.price(),
-//                    product.likeCount(),
-//                    product.status(),
-//                    product.createdAt()
-//            );
-//        }
+    }
+
+    public record Like(
+            Long targetId,
+            LikeTargetType targetType
+    ) {
+        public static LikeInfo.Like of(Long targetId, LikeTargetType targetType) {
+            return new LikeInfo.Like(targetId, targetType);
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeInfo.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.product.Product;
+
+import java.time.LocalDateTime;
+
+public class LikeInfo {
+    public record LikedProduct(
+            Long id,
+            String name,
+            int price,
+            long likeCount,
+            Product.Status status,
+            LocalDateTime createdAt
+    ) {
+//        public static LikeInfo.LikedProduct from(LikedProduct product) {
+//            return new LikeInfo.LikedProduct(
+//                    product.id(),
+//                    product.name(),
+//                    product.price(),
+//                    product.likeCount(),
+//                    product.status(),
+//                    product.createdAt()
+//            );
+//        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.product.ProductSku;
+import com.loopers.infrastructure.like.LikeJpaRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikeRepository {
+    void save(Like like);
+
+    void delete(Like like);
+
+    Optional<Like> findLike(Long userId, Long targetId, LikeTargetType targetType);
+
+    long countByTargetId(Long targetId, LikeTargetType targetType);
+
+    List<LikedProductProjection> findLikedProducts(Long userId, int offset, int limit);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,0 +1,43 @@
+package com.loopers.domain.like;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public void save(Long userId, Long targetId, LikeTargetType targetType) {
+        Like like = Like.create(userId, targetId, targetType);
+        likeRepository.save(like);
+    }
+
+    public void delete(Long userId,  Long targetId, LikeTargetType targetType) {
+        Like like = likeRepository.findLike(userId, targetId, targetType)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST,"해당 좋아요가 존재하지 않습니다. "));
+        likeRepository.delete(like);
+    }
+
+    public long getLikeCount(Long targetId, LikeTargetType targetType) {
+        return likeRepository.countByTargetId(targetId, targetType);
+    }
+
+    public List<LikedProduct> getLikedProducts(Long userId, int page, int size) {
+        return likeRepository.findLikedProducts(userId, page * size, size).stream()
+                .map(p -> LikedProduct.of(
+                        p.getId(),
+                        p.getName(),
+                        p.getMinPrice(),
+                        p.getLikeCount(),
+                        p.getStatus(),
+                        p.getCreatedAt()
+                ))
+                .toList();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeTargetType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeTargetType.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.like;
+
+public enum LikeTargetType {
+    BRAND, PRODUCT, REVIEW
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeValidator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeValidator.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.like;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LikeValidator {
+
+    private final LikeRepository likeRepository;
+
+    public void validateNotExists(Long userId, Long targetId, LikeTargetType targetType) {
+        boolean exists = likeRepository.findLike(userId, targetId, targetType).isPresent();
+
+        if (exists) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"이미 좋아요한 대상입니다.");
+        }
+    }
+    public void validateExists(Long userId, Long targetId, LikeTargetType targetType) {
+        boolean exists = likeRepository.findLike(userId, targetId, targetType).isPresent();
+
+        if (!exists) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"해당 좋아요가 존재하지 않습니다. ");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikedProduct.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikedProduct.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.product.Product;
+
+import java.time.LocalDateTime;
+
+public record LikedProduct(
+        Long id,
+        String name,
+        int price,
+        long likeCount,
+        Product.Status status,
+        LocalDateTime createdAt
+) {
+    public static LikedProduct of(Long id, String name, int price, long likeCount, Product.Status status, LocalDateTime createdAt) {
+        return new LikedProduct(id, name, price, likeCount, status, createdAt);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikedProductProjection.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikedProductProjection.java
@@ -1,0 +1,14 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.product.Product;
+
+import java.time.LocalDateTime;
+
+public interface LikedProductProjection {
+    Long getId();
+    String getName();
+    Integer getMinPrice();
+    Long getLikeCount();
+    Product.Status getStatus();
+    LocalDateTime getCreatedAt();
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -1,0 +1,74 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "orders")
+public class Order extends BaseEntity {
+
+    public enum Status {
+        PENDING,
+        CONFIRMED,
+        CANCELED
+    }
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    public void addOrderItem(OrderItem item) {
+        this.orderItems.add(item);
+        item.setOrder(this);
+    }
+
+    public void addPrice(Long amount) {
+        this.price += amount;
+    }
+
+    public void cancel() {
+        if (this.status == Status.CANCELED) {
+            throw new IllegalStateException("이미 취소된 주문입니다.");
+        }
+        this.status = Status.CANCELED;
+    }
+
+    public void isConfirmed() {
+        if (this.status == Status.CONFIRMED) {
+            throw new IllegalStateException("이미 결제된 주문입니다.");
+        }
+    }
+
+    public void confirm() {
+        if (this.status != Status.PENDING) {
+            throw new IllegalStateException("결제 전 상태에서만 확정할 수 있습니다.");
+        }
+        this.status = Status.CONFIRMED;
+    }
+
+    public static Order create(Long userId,Long price) {
+        return Order.builder()
+                .userId(userId)
+                .price(price)
+                .status(Status.PENDING)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -15,4 +15,14 @@ public class OrderCommand {
             Long productSkuId,
             int quantity
     ) {}
+
+    public record CancelOrder(
+            String loginId,
+            Long orderId
+    ) {}
+
+    public record OrderDetail(
+            String loginId,
+            Long orderId
+    ) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.order;
+
+import java.util.List;
+
+public class OrderCommand {
+
+    public record CreateOrder(
+            String loginId,
+            List<OrderItemCommand> items
+    ) {
+
+    }
+
+    public record OrderItemCommand(
+            Long productSkuId,
+            int quantity
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
@@ -78,4 +78,20 @@ public class OrderInfo {
             );
         }
     }
+
+    public record CancelOrder(
+            Long orderId,
+            Long userId,
+            Order.Status status,
+            ZonedDateTime updatedAt
+    ) {
+        public static CancelOrder from(Order order) {
+            return new CancelOrder(
+                    order.getId(),
+                    order.getUserId(),
+                    order.getStatus(),
+                    order.getUpdatedAt()
+            );
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.order;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class OrderInfo {
+
+    public record CreateOrder(
+            Long orderId,
+            Long userId,
+            Long price,
+            Order.Status status,
+            ZonedDateTime createdAt,
+            List<OrderItemInfo> items
+    ) {
+        public static CreateOrder from(Order order) {
+            return new CreateOrder(
+                    order.getId(),
+                    order.getUserId(),
+                    order.getPrice(),
+                    order.getStatus(),
+                    order.getCreatedAt(),
+                    order.getOrderItems().stream()
+                            .map(OrderItemInfo::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record OrderItemInfo(
+            Long productSkuId,
+            int quantity
+    ) {
+        public static OrderItemInfo from(OrderItem item) {
+            return new OrderItemInfo(
+                    item.getProductSkuId(),
+                    item.getQuantity()
+            );
+        }
+    }
+
+    public record OrderListItem(
+            Long orderId,
+            Long userId,
+            Long price,
+            Order.Status status,
+            ZonedDateTime createdAt
+    ) {
+        public static OrderListItem from(Order order) {
+            return new OrderListItem(
+                    order.getId(),
+                    order.getUserId(),
+                    order.getPrice(),
+                    order.getStatus(),
+                    order.getCreatedAt()
+            );
+        }
+    }
+
+    public record OrderDetail(
+            Long orderId,
+            Long userId,
+            Long price,
+            com.loopers.domain.order.Order.Status status,
+            ZonedDateTime createdAt,
+            List<OrderItemInfo> items
+    ) {
+        public static OrderDetail from(Order order) {
+            return new OrderDetail(
+                    order.getId(),
+                    order.getUserId(),
+                    order.getPrice(),
+                    order.getStatus(),
+                    order.getCreatedAt(),
+                    order.getOrderItems().stream()
+                            .map(OrderItemInfo::from)
+                            .toList()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderItem.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "order_item")
+public class OrderItem extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false, updatable = false)
+    private Order order;
+
+    @Column(name = "product_sku_id", nullable = false, updatable = false)
+    private Long productSkuId;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    public static OrderItem create(Long productSkuId, int quantity) {
+        return OrderItem.builder()
+                .productSkuId(productSkuId)
+                .quantity(quantity)
+                .build();
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.order;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderRepository {
+    Order save(Order order);
+    Optional<Order> findById(Long id);
+    List<Order> findByUserId(Long userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.order;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+
+    public Order saveOrder(Order order) {
+        return orderRepository.save(order);
+    }
+
+    public Order getOrder(Long orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 주문입니다."));
+    }
+
+    public List<Order> getOrdersByUserId(Long userId) {
+        return orderRepository.findByUserId(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.order;
 
+import com.loopers.domain.user.User;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -24,5 +25,22 @@ public class OrderService {
 
     public List<Order> getOrdersByUserId(Long userId) {
         return orderRepository.findByUserId(userId);
+    }
+
+    public void validateCancelable(Order order, User user) {
+        if (!order.getUserId().equals(user.getId())) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"본인의 주문만 취소할 수 있습니다.");
+        }
+        if (order.getStatus() == Order.Status.CANCELED) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"이미 취소된 주문입니다.");
+        }
+        if (order.getStatus() == Order.Status.CONFIRMED) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"결제 완료된 주문은 취소할 수 없습니다.");
+        }
+    }
+
+    public void cancelOrder(Order order) {
+        order.cancel();
+        orderRepository.save(order);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "payment")
+public class Payment extends BaseEntity {
+
+    public enum Method {
+        POINT, CREDIT
+    }
+
+    public enum Status {
+        PAID, CANCELLED
+    }
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(name = "order_id", nullable = false, updatable = false)
+    private Long orderId;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Method method;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    public void cancel() {
+        if (this.status == Status.CANCELLED) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이미 취소된 결제입니다.");
+        }
+        this.status = Status.CANCELLED;
+    }
+
+    public static Payment create(Long userId, Long orderId, Long amount, Method method) {
+        return Payment.builder()
+                .userId(userId)
+                .orderId(orderId)
+                .amount(amount)
+                .method(method)
+                .status(Status.PAID)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
@@ -7,4 +7,10 @@ public class PaymentCommand {
             Long amount,
             String method // "POINT" or "CREDIT"
     ) {}
+
+    public record CancelPayment(
+            String loginId,
+            Long orderId,
+            Long paymentId
+    ) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.payment;
+
+public class PaymentCommand {
+    public record CreatePayment(
+            String loginId,
+            Long orderId,
+            Long amount,
+            String method // "POINT" or "CREDIT"
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.payment;
+
+import java.time.ZonedDateTime;
+
+public class PaymentInfo {
+    public record CreatePayment(
+            Long paymentId,
+            Long userId,
+            Long orderId,
+            Long amount,
+            Payment.Method method,
+            Payment.Status status,
+            ZonedDateTime createdAt
+    ) {
+        public static CreatePayment from(Payment payment) {
+            return new CreatePayment(
+                    payment.getId(),
+                    payment.getUserId(),
+                    payment.getOrderId(),
+                    payment.getAmount(),
+                    payment.getMethod(),
+                    payment.getStatus(),
+                    payment.getCreatedAt()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
@@ -24,4 +24,24 @@ public class PaymentInfo {
             );
         }
     }
+
+    public record CancelPayment(
+            Long paymentId,
+            Long orderId,
+            Long userId,
+            Payment.Method method,
+            Payment.Status status,
+            ZonedDateTime updatedAt
+    ) {
+        public static CancelPayment from(Payment payment) {
+            return new CancelPayment(
+                    payment.getId(),
+                    payment.getOrderId(),
+                    payment.getUserId(),
+                    payment.getMethod(),
+                    payment.getStatus(),
+                    payment.getUpdatedAt()
+            );
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment;
+
+import java.util.Optional;
+
+public interface PaymentRepository {
+    Payment save(Payment payment);
+    Optional<Payment> findById(Long id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -1,5 +1,8 @@
 package com.loopers.domain.payment;
 
+import com.loopers.domain.user.User;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,5 +14,25 @@ public class PaymentService {
 
     public Payment save(Payment payment) {
         return paymentRepository.save(payment);
+    }
+
+    public Payment getPayment(Long paymentId) {
+        return paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 결제입니다."));
+    }
+
+    public void validateCancelable(Payment payment, User user) {
+        if (!payment.getUserId().equals(user.getId())) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"본인의 결제만 취소할 수 있습니다.");
+        }
+        if (payment.getStatus() == Payment.Status.CANCELLED) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"이미 취소된 결제입니다.");
+        }
+    }
+
+    public Payment cancelPayment(Payment currPayment) {
+        currPayment.cancel();
+        Payment payment = paymentRepository.save(currPayment);
+        return payment;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.payment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    public Payment save(Payment payment) {
+        return paymentRepository.save(payment);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -27,9 +27,10 @@ public class Product extends BaseEntity {
     private Long brandId;
 
     public enum Status {
-        ACTIVE,
-        INACTIVE,
-        SOLD_OUT
+        ACTIVE, // 판매중
+        INACTIVE, // 판매중지
+        SOLD_OUT, // 완전품절
+        TEMPORARILY_UNAVAILABLE, // 일시품절
     }
 
     public static Product create(String name, Product.Status status, Long brandId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -1,0 +1,50 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "product")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Product extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Product.Status status;
+
+    @Column(name = "brand_id", nullable = false)
+    private Long brandId;
+
+    public enum Status {
+        ACTIVE,
+        INACTIVE,
+        SOLD_OUT
+    }
+
+    public static Product create(String name, Product.Status status, Long brandId) {
+        return Product.builder()
+                .name(name)
+                .status(Product.Status.ACTIVE)
+                .brandId(brandId)
+                .build();
+    }
+
+    public boolean isAvailable() {
+        return this.status == Product.Status.ACTIVE;
+    }
+
+    public void changeStatus(Product.Status status) {
+        this.status = status;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.product;
+
+public class ProductCommand {
+
+    public record List(
+            int page,
+            int size,
+            Long brandId,
+            ProductSortType sortType
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductInfo.java
@@ -1,0 +1,67 @@
+package com.loopers.domain.product;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ProductInfo {
+
+    public record Summary(
+            Long id,
+            String name,
+            int price,
+            long likeCount,
+            String status,
+            LocalDateTime createdAt
+    ) {
+        public static Summary from(ProductSummary summary) {
+            return new Summary(
+                    summary.id(),
+                    summary.name(),
+                    summary.price(),
+                    summary.likeCount(),
+                    summary.status().name(),
+                    summary.createdAt()
+            );
+        }
+    }
+
+    public record Detail(
+            Long id,
+            String name,
+            Product.Status status,
+            Long brandId,
+            String brandName,
+            long likeCount,
+            List<Sku> skus
+    ) {
+        public static Detail from(Product product, String brandName, List<ProductSku> skus, long likeCount) {
+            return new Detail(
+                    product.getId(),
+                    product.getName(),
+                    product.getStatus(),
+                    product.getBrandId(),
+                    brandName,
+                    likeCount,
+                    skus.stream().map(Sku::from).toList()
+            );
+        }
+    }
+
+    public record Sku(
+            Long id,
+            String sku,
+            int price,
+            int stockTotal,
+            int stockReserved
+    ) {
+        public static Sku from(ProductSku sku) {
+            return new Sku(
+                    sku.getId(),
+                    sku.getSku(),
+                    sku.getPrice(),
+                    sku.getStockTotal(),
+                    sku.getStockReserved()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOption.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOption.java
@@ -1,0 +1,29 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "product_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProductOption extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    public static ProductOption create(Product product, String name) {
+        return ProductOption.builder()
+                .product(product)
+                .name(name)
+                .build();
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionValue.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductOptionValue.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "product_option_value")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProductOptionValue extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id")
+    private ProductOption option;
+
+    @Column(name = "value", nullable = false)
+    private String value;
+
+    public static ProductOptionValue create(ProductOption option, String value) {
+        return ProductOptionValue.builder()
+                .option(option)
+                .value(value)
+                .build();
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.product;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductRepository {
+
+    List<ProductSummaryProjection> findProductSummaries(Long brandId, ProductSortType sortType, int page, int size);
+
+    Optional<Product> findBy(Long productId);
+
+    Optional<ProductSku> findBySkuId(Long skuId);
+
+    List<ProductSku> findAllByProductId(Long productId);
+
+    Product saveProduct(Product product);
+
+    ProductSku saveProductSku(ProductSku productSku);
+
+    boolean existsAvailableStock(Long productId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -1,0 +1,55 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public List<ProductSummary> getProductSummaries(ProductCommand.List command) {
+        List<ProductSummaryProjection> projections = productRepository.findProductSummaries(
+                command.brandId(),
+                command.sortType(),
+                command.page(),
+                command.size()
+        );
+
+        return projections.stream()
+                .map(p -> new ProductSummary(
+                        p.getId(),
+                        p.getName(),
+                        p.getMinPrice(),
+                        p.getLikeCount(),
+                        p.getStatus(),
+                        p.getCreatedAt()
+                ))
+                .toList();
+    }
+
+    public Product getProduct(Long productId) {
+        Product product = productRepository.findBy(productId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 상품 ID: " + productId));
+
+        if (!product.isAvailable()) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"판매중인 상품이 아닙니다.");
+        }
+        return product;
+    }
+
+    public void updateStatus(boolean isAllSoldOut, Long productId) {
+        if (!isAllSoldOut) return;
+
+        Product product = productRepository.findBy(productId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 상품 ID: " + productId));
+
+        product.changeStatus(Product.Status.SOLD_OUT);
+        productRepository.saveProduct(product);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
@@ -1,0 +1,63 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "product_sku")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProductSku extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "sku", nullable = false, unique = true)
+    private String sku;
+
+    @Column(name = "price", nullable = false)
+    private int price;
+
+    @Column(name = "stock_total", nullable = false)
+    private int stockTotal;
+
+    @Column(name = "stock_reserved", nullable = false)
+    private int stockReserved;
+
+    public static ProductSku create(Product product, String sku, int price, int stockTotal, int stockReserved) {
+        return ProductSku.builder()
+                .product(product)
+                .sku(sku)
+                .price(price)
+                .stockTotal(stockTotal)
+                .stockReserved(stockReserved)
+                .build();
+    }
+
+    public boolean isSoldOut() {
+        return (stockTotal - stockReserved) <= 0;
+    }
+
+    public int avaliableQunatity() {
+        return (stockTotal - stockReserved);
+    }
+
+    public void reserveStock(int quantity) {
+        if (avaliableQunatity() < quantity) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다.");
+        }
+
+        stockReserved += quantity;
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
@@ -28,11 +28,21 @@ public class ProductSku extends BaseEntity {
     @Column(name = "price", nullable = false)
     private int price;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ProductSku.Status status;
+
     @Column(name = "stock_total", nullable = false)
     private int stockTotal;
 
     @Column(name = "stock_reserved", nullable = false)
     private int stockReserved;
+
+    public enum Status {
+        ACTIVE,
+        INACTIVE,
+        SOLD_OUT
+    }
 
     public static ProductSku create(Product product, String sku, int price, int stockTotal, int stockReserved) {
         return ProductSku.builder()
@@ -56,8 +66,14 @@ public class ProductSku extends BaseEntity {
         if (avaliableQunatity() < quantity) {
             throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다.");
         }
-
         stockReserved += quantity;
+    }
+
+    public void rollbackStock(int quantity) {
+        if(stockReserved < quantity){
+            throw new CoreException(ErrorType.BAD_REQUEST, "요청재고는 선점재고를 초과할 수 없습니다.");
+        }
+        stockReserved -= quantity;
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuOptionValue.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuOptionValue.java
@@ -1,0 +1,35 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "product_sku_option_value", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"sku_id", "option_value_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProductSkuOptionValue extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sku_id")
+    private ProductSku sku;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_value_id", nullable = false, updatable = false)
+    private ProductOptionValue optionValue;
+
+    public static ProductSkuOptionValue create(ProductSku sku, ProductOptionValue optionValue) {
+        return ProductSkuOptionValue.builder()
+                .sku(sku)
+                .optionValue(optionValue)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
@@ -30,6 +30,12 @@ public class ProductSkuService {
         productRepository.saveProductSku(sku);
     }
 
+    public void rollbackReservedStock(Long skuId, int quantity) {
+        ProductSku sku = getBySkuId(skuId);
+        sku.rollbackStock(quantity);
+        productRepository.saveProductSku(sku);
+    }
+
     public boolean isAllSoldOut(Long productId) {
         return productRepository.existsAvailableStock(productId);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSkuService.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ProductSkuService {
+
+    private final ProductRepository productRepository;
+
+    public List<ProductSku> getByProductId(Long productId) {
+        return productRepository.findAllByProductId(productId);
+    }
+
+    public ProductSku getBySkuId(Long skuId) {
+        return productRepository.findBySkuId(skuId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 상품 SKUID: " + skuId));
+    }
+
+    public void reserveStock(ProductSku sku, int qty) {
+        if (sku.avaliableQunatity() < qty) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"재고가 부족합니다.");
+        }
+        sku.reserveStock(qty);
+        productRepository.saveProductSku(sku);
+    }
+
+    public boolean isAllSoldOut(Long productId) {
+        return productRepository.existsAvailableStock(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSortType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSortType.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.product;
+
+public enum ProductSortType {
+    RECENT,
+    LOW_PRICE,
+    LIKE;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSummary.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSummary.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.product;
+
+import java.time.LocalDateTime;
+
+public record ProductSummary(
+        Long id,
+        String name,
+        int price,
+        long likeCount,
+        Product.Status status,
+        LocalDateTime createdAt
+) {
+    public static ProductSummary from(Product product, int minPrice, long likeCount, Product.Status status,LocalDateTime createdAt) {
+        return new ProductSummary(
+                product.getId(),
+                product.getName(),
+                minPrice,
+                likeCount,
+                status,
+                createdAt
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSummaryProjection.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSummaryProjection.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.product;
+
+import java.time.LocalDateTime;
+
+public interface ProductSummaryProjection {
+    Long getId();
+    String getName();
+    Integer getMinPrice();
+    Long getLikeCount();
+    Product.Status getStatus();
+    LocalDateTime getCreatedAt();
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -11,7 +11,8 @@ import lombok.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserEntity extends BaseEntity {
+@Builder
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,7 +41,7 @@ public class UserEntity extends BaseEntity {
         M, F
     }
 
-    public UserEntity(String loginId, Gender gender, String name, String birth, String email) {
+    public User(String loginId, Gender gender, String name, String birth, String email) {
 
         if (loginId == null || !loginId.matches("^[a-zA-Z0-9]{1,10}$")) {
             throw new CoreException(
@@ -71,7 +72,7 @@ public class UserEntity extends BaseEntity {
         this.point = 0L;
     }
 
-    public UserEntity(String loginId, Gender gender, String name, String birth, String email, Long point) {
+    public User(String loginId, Gender gender, String name, String birth, String email, Long point) {
         this.loginId = loginId;
         this.gender = gender;
         this.name = name;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserCommand.java
@@ -7,13 +7,13 @@ public class UserCommand {
     @Builder
     public record SignUp(
             String loginId,
-            UserEntity.Gender gender,
+            User.Gender gender,
             String name,
             String birth,
             String email
     ){
-        public UserEntity toModel() {
-            return new UserEntity(
+        public User toModel() {
+            return new User(
                     this.loginId,
                     this.gender,
                     this.name,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserInfo.java
@@ -5,12 +5,12 @@ public class UserInfo {
     public record UserDetail (
             Long id,
             String loginId,
-            UserEntity.Gender gender,
+            User.Gender gender,
             String name,
             String birth,
             String email
     ) {
-        public static UserDetail from (UserEntity model){
+        public static UserDetail from (User model){
             return new UserDetail(
                     model.getId(),
                     model.getLoginId(),
@@ -28,7 +28,7 @@ public class UserInfo {
             String name,
             Long point
     ){
-        public static Point from (UserEntity model){
+        public static Point from (User model){
             return new Point(
                     model.getId(),
                     model.getLoginId(),

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -3,8 +3,8 @@ package com.loopers.domain.user;
 import java.util.Optional;
 
 public interface UserRepository {
-    Optional<UserEntity> findByLoginId(String loginId);
-    UserEntity save(UserEntity user);
+    Optional<User> findByLoginId(String loginId);
+    User save(User user);
     boolean existsByLoginId(String loginId);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -44,7 +44,7 @@ public class UserService {
         return UserInfo.Point.from(point);
     }
 
-    @Transactional(readOnly = true)
+
     public UserInfo.Point myPoint(String loginId){
         User user = userRepository.findByLoginId(loginId).orElse(null);
         return user == null ? null : UserInfo.Point.from(user);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -15,31 +15,38 @@ public class UserService {
     @Transactional
     public UserInfo.UserDetail signUp(UserCommand.SignUp command){
         boolean isExists = userRepository.existsByLoginId(command.loginId());
-        UserEntity.validateUniqueLoginId(isExists);
-        UserEntity user = userRepository.save(command.toModel());
+        User.validateUniqueLoginId(isExists);
+        User user = userRepository.save(command.toModel());
         return UserInfo.UserDetail.from(user);
     }
 
     @Transactional(readOnly = true)
     public UserInfo.UserDetail myProfile(String loginId) {
-        UserEntity user = userRepository.findByLoginId(loginId).orElse(null);
+        User user = userRepository.findByLoginId(loginId).orElse(null);
         return user == null ? null : UserInfo.UserDetail.from(user);
+    }
+
+    public User getUser(String loginId) {
+        User user = userRepository.findByLoginId(loginId).orElseThrow(
+                () -> new CoreException(ErrorType.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
+        );
+        return user;
     }
 
     @Transactional
     public UserInfo.Point charge(UserCommand.Charge command){
-        UserEntity currPoint = userRepository.findByLoginId(command.loginId()).orElseThrow(
+        User currPoint = userRepository.findByLoginId(command.loginId()).orElseThrow(
                 () -> new CoreException(ErrorType.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
         );
         currPoint.charge(command.amount());
-        UserEntity point = userRepository.save(currPoint);
+        User point = userRepository.save(currPoint);
 
         return UserInfo.Point.from(point);
     }
 
     @Transactional(readOnly = true)
     public UserInfo.Point myPoint(String loginId){
-        UserEntity user = userRepository.findByLoginId(loginId).orElse(null);
+        User user = userRepository.findByLoginId(loginId).orElse(null);
         return user == null ? null : UserInfo.Point.from(user);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BrandJpaRepository extends JpaRepository<Brand,Long> {
+    Optional<Brand> findById(String name);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface BrandJpaRepository extends JpaRepository<Brand,Long> {
-    Optional<Brand> findById(String name);
+    Optional<Brand> findById(Long brandId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.brand;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class BrandRepositoryImpl implements BrandRepository {
+
+    private final BrandJpaRepository brandJpaRepository;
+
+    @Override
+    public Optional<Brand> findById(long id) {
+        return brandJpaRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeJpaRepository.java
@@ -1,0 +1,72 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.Like;
+import com.loopers.domain.like.LikeTargetType;
+import com.loopers.domain.like.LikedProductProjection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LikeJpaRepository extends JpaRepository<Like, Long> {
+
+    @Query("""
+        SELECT COUNT(l)
+        FROM Like l
+        WHERE l.targetId = :targetId
+          AND l.targetType = :targetType
+    """)
+    long countByTargetIdAndTargetType(
+            @Param("targetId") Long targetId,
+            @Param("targetType") LikeTargetType targetType
+    );
+
+    @Query("""
+        SELECT l FROM Like l 
+        WHERE l.userId = :userId 
+          AND l.targetId = :targetId 
+          AND l.targetType = :targetType
+    """)
+    Optional<Like> findLike(
+            Long userId, Long targetId,
+            LikeTargetType targetType
+    );
+
+    @Query("""
+        SELECT COUNT(l) > 0 FROM Like l 
+        WHERE l.userId = :userId 
+          AND l.targetId = :targetId 
+          AND l.targetType = :targetType
+    """)
+    boolean existsLike(
+            Long userId,
+            Long targetId,
+            LikeTargetType targetType
+    );
+
+    @Query(value = """
+        SELECT 
+            p.id AS id,
+            p.name AS name,
+            COALESCE(MIN(s.price), 0) AS minPrice,
+            COUNT(l2.id) AS likeCount,
+            p.status AS status,
+            p.created_at AS createdAt
+        FROM Like l
+        JOIN product p ON p.id = l.target_id
+        LEFT JOIN product_sku s ON s.product_id = p.id
+        LEFT JOIN likes l2 ON l2.target_id = p.id AND l2.target_type = 'PRODUCT'
+        WHERE l.user_id = :userId
+          AND l.target_type = 'PRODUCT'
+        GROUP BY p.id, p.name, p.status, p.created_at
+        ORDER BY l.created_at DESC
+        LIMIT :limit OFFSET :offset
+    """, nativeQuery = true)
+    List<LikedProductProjection> findLikedProducts(
+            @Param("userId") Long userId,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.Like;
+import com.loopers.domain.like.LikeRepository;
+import com.loopers.domain.like.LikeTargetType;
+import com.loopers.domain.like.LikedProductProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeRepositoryImpl implements LikeRepository {
+
+    private final LikeJpaRepository likeJpaRepository;
+
+    @Override
+    public void save(Like like) {
+        likeJpaRepository.save(like);
+    }
+
+    @Override
+    public void delete(Like like) {
+        likeJpaRepository.delete(like);
+    }
+
+    @Override
+    public Optional<Like> findLike(Long userId, Long targetId, LikeTargetType targetType) {
+        return likeJpaRepository.findLike(userId, targetId, targetType);
+    }
+
+    @Override
+    public long countByTargetId(Long targetId, LikeTargetType targetType) {
+        return likeJpaRepository.countByTargetIdAndTargetType(targetId, targetType);
+    }
+
+    @Override
+    public List<LikedProductProjection> findLikedProducts(Long userId, int offset, int limit) {
+        return likeJpaRepository.findLikedProducts(userId, offset, limit);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderItemJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderItemJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderItemJpaRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+    List<Order> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+
+    private final OrderJpaRepository orderJpaRepository;
+
+    @Override
+    public Order save(Order order) {
+        return orderJpaRepository.save(order);
+    }
+
+    @Override
+    public Optional<Order> findById(Long id) {
+        return orderJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Order> findByUserId(Long userId) {
+        return orderJpaRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements PaymentRepository {
+
+    private final PaymentJpaRepository jpaRepository;
+
+    @Override
+    public Payment save(Payment payment) {
+        return jpaRepository.save(payment);
+    }
+
+    @Override
+    public Optional<Payment> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,0 +1,44 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductSummaryProjection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+
+    @Query(value = """
+        SELECT 
+            p.id AS id,
+            p.name AS name,
+            (
+                SELECT MIN(s.price)
+                FROM product_sku s
+                WHERE s.product_id = p.id
+            ) AS minPrice,
+            (
+                SELECT COUNT(l.id)
+                FROM likes l
+                WHERE l.target_id = p.id AND l.target_type = 'PRODUCT'
+            ) AS likeCount,
+            p.status AS status,
+            p.created_at AS createdAt
+        FROM product p
+        WHERE p.status = 'ACTIVE'
+        AND (:brandId IS NULL OR p.brand_id = :brandId)
+        ORDER BY 
+            CASE WHEN :sort = 'RECENT' THEN p.created_at END DESC,
+            CASE WHEN :sort = 'LOW_PRICE' THEN minPrice END ASC,
+            CASE WHEN :sort = 'LIKE' THEN likeCount END DESC
+        LIMIT :limit OFFSET :offset
+        """, nativeQuery = true)
+    List<ProductSummaryProjection> findProductSummaries(
+            @Param("brandId") Long brandId,
+            @Param("sort") String sort,
+            @Param("limit") int limit,
+            @Param("offset") int offset
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -1,0 +1,56 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class ProductRepositoryImpl implements ProductRepository {
+
+    private final ProductJpaRepository productJpaRepository;
+    private final ProductSkuJpaRepository productSkuJpaRepository;
+
+    @Override
+    public List<ProductSummaryProjection> findProductSummaries(Long brandId, ProductSortType sortType, int page, int size) {
+        return productJpaRepository.findProductSummaries(
+                brandId,
+                sortType.name(),
+                size,
+                page * size
+        );
+    }
+
+    @Override
+    public Optional<Product> findBy(Long productId) {
+        return productJpaRepository.findById(productId);
+    }
+
+    @Override
+    public Optional<ProductSku> findBySkuId(Long skuId) {
+        return productSkuJpaRepository.findById(skuId);
+    }
+
+    @Override
+    public List<ProductSku> findAllByProductId(Long productId) {
+        return productSkuJpaRepository.findAllByProductId(productId);
+    }
+
+    @Override
+    public Product saveProduct(Product product) {
+        return productJpaRepository.save(product);
+    }
+
+    @Override
+    public ProductSku saveProductSku(ProductSku productSku) {
+        return productSkuJpaRepository.save(productSku);
+    }
+
+    @Override
+    public boolean existsAvailableStock(Long productId) {
+        return productSkuJpaRepository.existsAvailableStock(productId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
@@ -1,0 +1,26 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.ProductSku;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ProductSkuJpaRepository extends JpaRepository<ProductSku, Long> {
+
+    @Query("SELECT s FROM ProductSku s WHERE s.product.id = :productId")
+    List<ProductSku> findAllByProductId(@Param("productId") Long productId);
+
+    @Query("""
+    SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END
+    FROM ProductSku s
+    WHERE s.product.id = :productId
+      AND (s.stockTotal - s.stockReserved) > 0
+""")
+    boolean existsAvailableStock(@Param("productId") Long productId);
+
+}
+
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,16 +1,16 @@
 package com.loopers.infrastructure.user;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
+public interface UserJpaRepository extends JpaRepository<User, Long> {
 
-    @Query("SELECT u FROM UserEntity u WHERE u.loginId = :loginId")
-    Optional<UserEntity> findbyLoginId(@Param("loginId") String loginId);
+    @Query("SELECT u FROM User u WHERE u.loginId = :loginId")
+    Optional<User> findbyLoginId(@Param("loginId") String loginId);
 
     boolean existsByLoginId(String loginId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.loopers.infrastructure.user;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -13,12 +13,12 @@ public class UserRepositoryImpl implements UserRepository {
     private final UserJpaRepository jpaRepository;
 
     @Override
-    public Optional<UserEntity> findByLoginId(String loginId) {
+    public Optional<User> findByLoginId(String loginId) {
         return jpaRepository.findbyLoginId(loginId);
     }
 
     @Override
-    public UserEntity save(UserEntity user) {
+    public User save(User user) {
         return jpaRepository.save(user);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandController.java
@@ -2,7 +2,6 @@ package com.loopers.interfaces.api.controller.brand;
 
 import com.loopers.application.brand.BrandUsecase;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.interfaces.api.controller.user.UserV1Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,13 +11,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/brands")
 @RequiredArgsConstructor
-public class BrandController {
+public class BrandController implements BrandV1ApiSpec {
 
     private final BrandUsecase brandUsecase;
 
     @GetMapping("/{brandId}")
-    public ApiResponse<BrandResponse> getBrandInfo(@PathVariable Long brandId) {
-        BrandResponse response = brandUsecase.getBrandInfo(brandId);
+    public ApiResponse<BrandV1Response> getBrandInfo(@PathVariable Long brandId) {
+        BrandV1Response response = brandUsecase.getBrandInfo(brandId);
         return ApiResponse.success(response);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandController.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.controller.brand;
+
+import com.loopers.application.brand.BrandUsecase;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.interfaces.api.controller.user.UserV1Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/brands")
+@RequiredArgsConstructor
+public class BrandController {
+
+    private final BrandUsecase brandUsecase;
+
+    @GetMapping("/{brandId}")
+    public ApiResponse<BrandResponse> getBrandInfo(@PathVariable Long brandId) {
+        BrandResponse response = brandUsecase.getBrandInfo(brandId);
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandResponse.java
@@ -1,0 +1,17 @@
+package com.loopers.interfaces.api.controller.brand;
+
+import com.loopers.domain.brand.Brand;
+
+public record BrandResponse(
+        Long id,
+        String name,
+        String description
+) {
+    public static BrandResponse from(Brand brand) {
+        return new BrandResponse(
+                brand.getId(),
+                brand.getName(),
+                brand.getDescription()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandV1ApiSpec.java
@@ -1,0 +1,19 @@
+package com.loopers.interfaces.api.controller.brand;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "브랜드", description = "브랜드관련API")
+public interface BrandV1ApiSpec {
+
+    @Operation(
+            summary = "브랜드정보 조회",
+            description = "유효한 `브랜드ID`를 입력하면 `브랜드ID`, `브랜드명`, `설명` 등을 확인할 수 있다."
+    )
+    ApiResponse<BrandV1Response> getBrandInfo(
+            @Schema(name = "브랜드ID", description = "사용자가 조회요청한 브랜드의 ID")
+            @PathVariable Long brandId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandV1Response.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/brand/BrandV1Response.java
@@ -2,13 +2,13 @@ package com.loopers.interfaces.api.controller.brand;
 
 import com.loopers.domain.brand.Brand;
 
-public record BrandResponse(
+public record BrandV1Response(
         Long id,
         String name,
         String description
 ) {
-    public static BrandResponse from(Brand brand) {
-        return new BrandResponse(
+    public static BrandV1Response from(Brand brand) {
+        return new BrandV1Response(
                 brand.getId(),
                 brand.getName(),
                 brand.getDescription()

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeController.java
@@ -1,0 +1,50 @@
+package com.loopers.interfaces.api.controller.like;
+
+import com.loopers.application.like.LikeUsecase;
+import com.loopers.domain.like.LikeCommand;
+import com.loopers.domain.like.LikeInfo;
+import com.loopers.domain.like.LikeTargetType;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/likes")
+public class LikeController implements LikeV1ApiSpec {
+
+    private final LikeUsecase likeUsecase;
+
+    @PostMapping("/products/{productId}")
+    public ApiResponse<LikeV1Response.Like> likeProduct(
+            @RequestHeader("X-USER-ID") String loginId,
+            @PathVariable Long productId
+    ) {
+        LikeCommand.Like command = LikeCommand.Like.of(loginId, productId, LikeTargetType.PRODUCT);
+        LikeV1Response.Like like = LikeV1Response.Like.from(likeUsecase.like(command));
+        return ApiResponse.success(like);
+    }
+
+    @DeleteMapping("/products/{productId}")
+    public ApiResponse<?>  unlikeProduct(
+            @RequestHeader("X-USER-ID") String loginId,
+            @PathVariable Long productId
+    ) {
+        LikeCommand.Like command = LikeCommand.Like.of(loginId, productId, LikeTargetType.PRODUCT);
+        likeUsecase.unlike(command);
+        return ApiResponse.success();
+    }
+
+    @GetMapping("/{userId}/likes/products")
+    public ApiResponse<LikeV1Response.LikedProductList>  getLikedProducts(
+            @RequestHeader("X-USER-ID") String loginId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    ) {
+        LikeCommand.LikedProducts command = new LikeCommand.LikedProducts(loginId, LikeTargetType.PRODUCT, page, size);
+        List<LikeInfo.LikedProduct> infos = likeUsecase.getLikedProducts(command);
+        return ApiResponse.success(LikeV1Response.LikedProductList.from(infos));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeResponse.java
@@ -1,0 +1,43 @@
+package com.loopers.interfaces.api.controller.like;
+
+import com.loopers.domain.like.LikeInfo;
+import com.loopers.domain.product.Product;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class LikeResponse {
+
+    public record LikedProductList(
+            long totalCount,
+            List<LikedProduct> items
+    ) {
+        public static LikedProductList from(List<LikeInfo.LikedProduct> infos) {
+            return new LikedProductList(
+                    infos.size(),
+                    infos.stream().map(LikedProduct::from).toList()
+            );
+        }
+    }
+
+    public record LikedProduct(
+            Long id,
+            String name,
+            int price,
+            long likeCount,
+            Product.Status status,
+            LocalDateTime createdAt
+    ) {
+        public static LikedProduct from(LikeInfo.LikedProduct info) {
+            return new LikedProduct(
+                    info.id(),
+                    info.name(),
+                    info.price(),
+                    info.likeCount(),
+                    info.status(),
+                    info.createdAt()
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeV1ApiSpec.java
@@ -1,0 +1,46 @@
+package com.loopers.interfaces.api.controller.like;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "좋아요", description = "좋아요 관련 API")
+public interface LikeV1ApiSpec {
+
+    @Operation(
+            summary = "좋아요 등록",
+            description = "사용자는 상품에 좋아요를 등록할 수 있다."
+    )
+    ApiResponse<LikeV1Response.Like> likeProduct(
+            @Schema(name = "사용자정보", description = "사용자정보")
+            @RequestHeader("X-USER-ID") String loginId,
+            @Schema(name = "상품정보", description = "상품ID")
+            @PathVariable Long productId
+    );
+
+    @Operation(
+            summary = "좋아요 취소",
+            description = "사용자는 상품에 좋아요를 취소할 수 있다."
+    )
+    @DeleteMapping("/products/{productId}")
+    ApiResponse<?>  unlikeProduct(
+            @RequestHeader("X-USER-ID") String loginId,
+            @PathVariable Long productId
+    );
+
+    @Operation(
+            summary = "내가 좋아요한 상품 목록 조회",
+            description = "사용자는 자신이 좋아요한 상품 목록을 조회할 수 있다.."
+    )
+    @GetMapping("/{userId}/likes/products")
+    ApiResponse<LikeV1Response.LikedProductList>  getLikedProducts(
+            @Schema(name = "로그인 사용자 ID", description = "요청을 보낸 사용자의 고유 ID")
+            @RequestHeader("X-USER-ID") String loginId,
+            @Schema(name = "페이지 번호", description = "조회할 페이지 번호 (0부터 시작)")
+            @RequestParam(defaultValue = "0") int page,
+            @Schema(name = "페이지 당 항목 수", description = "한 페이지에 보여줄 상품의 개수")
+            @RequestParam(defaultValue = "5") int size
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeV1Response.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/like/LikeV1Response.java
@@ -1,12 +1,22 @@
 package com.loopers.interfaces.api.controller.like;
 
 import com.loopers.domain.like.LikeInfo;
+import com.loopers.domain.like.LikeTargetType;
 import com.loopers.domain.product.Product;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-public class LikeResponse {
+public class LikeV1Response {
+
+    public record Like(
+            Long targetId,
+            LikeTargetType targetType
+    ) {
+        public static LikeV1Response.Like from(LikeInfo.Like like) {
+            return new LikeV1Response.Like(like.targetId(), like.targetType());
+        }
+    }
 
     public record LikedProductList(
             long totalCount,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderController.java
@@ -1,0 +1,57 @@
+package com.loopers.interfaces.api.controller.order;
+
+import com.loopers.application.order.OrderUsecase;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+public class OrderController implements OrderV1ApiSpec {
+
+    private final OrderUsecase orderUsecase;
+
+    @PostMapping
+    public ApiResponse<OrderV1Response.CreateOrder> createOrder(@RequestHeader("X-USER-ID") String loginId, @RequestBody OrderV1Request.CreateOrder request) {
+        OrderCommand.CreateOrder command = new OrderCommand.CreateOrder(
+                loginId,
+                request.items().stream()
+                        .map(i -> new OrderCommand.OrderItemCommand(i.productSkuId(), i.quantity()))
+                        .toList()
+        );
+        var orderInfo = orderUsecase.order(command);
+        return ApiResponse.success(OrderV1Response.CreateOrder.from(orderInfo));
+    }
+
+    @GetMapping("")
+    public ApiResponse<List<OrderV1Response.OrderListItem>> getOrders(@RequestHeader("X-USER-ID") String loginId) {
+        var orders = orderUsecase.getOrdersByUserId(loginId)
+                .stream()
+                .map(OrderV1Response.OrderListItem::from)
+                .toList();
+        return ApiResponse.success(orders);
+    }
+
+    @GetMapping("/{orderId}")
+    public ApiResponse<OrderV1Response.OrderDetail> getOrderDetail(@PathVariable Long orderId) {
+        var orderDetail = orderUsecase.getOrderDetail(orderId);
+        return ApiResponse.success(OrderV1Response.OrderDetail.from(orderDetail));
+    }
+
+    @PatchMapping("/{orderId}/cancel")
+    public ApiResponse<OrderV1Response.CancelOrder> cancelOrder(
+            @RequestHeader("X-USER-ID") String loginId,
+            @PathVariable Long orderId
+    ) {
+        OrderCommand.CancelOrder command = new OrderCommand.CancelOrder(
+                loginId,
+                orderId
+        );
+        var cancelInfo = orderUsecase.cancelOrder(command);
+        return ApiResponse.success(OrderV1Response.CancelOrder.from(cancelInfo));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderRequest.java
@@ -1,0 +1,18 @@
+package com.loopers.interfaces.api.controller.order;
+
+import java.util.List;
+
+public class OrderRequest {
+
+    public record CreateOrder(
+            String loginId,
+            List<OrderItem> items
+    ) {
+    }
+
+    public record OrderItem(
+            Long productSkuId,
+            int quantity
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderResponse.java
@@ -1,0 +1,85 @@
+package com.loopers.interfaces.api.controller.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderInfo;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class OrderResponse {
+
+    public record CreateOrder(
+            Long orderId,
+            Long userId,
+            BigDecimal price,
+            Order.Status status,
+            ZonedDateTime createdAt,
+            List<OrderItemResponse> items
+    ) {
+        public static CreateOrder from(OrderInfo.CreateOrder info) {
+            return new CreateOrder(
+                    info.orderId(),
+                    info.userId(),
+                    BigDecimal.valueOf(info.price()),
+                    info.status(),
+                    info.createdAt(),
+                    info.items().stream()
+                            .map(OrderItemResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record OrderDetail(
+            Long orderId,
+            Long userId,
+            Long price,
+            String status,
+            ZonedDateTime createdAt,
+            List<OrderItemResponse> items
+    ) {
+        public static OrderDetail from(OrderInfo.OrderDetail info) {
+            return new OrderDetail(
+                    info.orderId(),
+                    info.userId(),
+                    info.price(),
+                    info.status().name(),
+                    info.createdAt(),
+                    info.items().stream()
+                            .map(OrderItemResponse::from)
+                            .toList()
+            );
+        }
+    }
+
+    public record OrderItemResponse(
+            Long productSkuId,
+            int quantity
+    ) {
+        public static OrderItemResponse from(OrderInfo.OrderItemInfo info) {
+            return new OrderItemResponse(
+                    info.productSkuId(),
+                    info.quantity()
+            );
+        }
+    }
+
+    public record OrderListItem(
+            Long orderId,
+            Long userId,
+            Long price,
+            String status,
+            ZonedDateTime createdAt
+    ) {
+        public static OrderListItem from(OrderInfo.OrderListItem info) {
+            return new OrderListItem(
+                    info.orderId(),
+                    info.userId(),
+                    info.price(),
+                    info.status().name(),
+                    info.createdAt()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderV1ApiSpec.java
@@ -1,0 +1,55 @@
+package com.loopers.interfaces.api.controller.order;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+@Tag(name = "주문", description = "주문 생성, 조회, 취소 관련 API")
+public interface OrderV1ApiSpec {
+
+    @Operation(
+            summary = "주문 생성",
+            description = "사용자가 장바구니에 담은 상품으로 주문을 생성한다."
+    )
+    @PostMapping
+    ApiResponse<OrderV1Response.CreateOrder> createOrder(
+            @Parameter(name = "X-USER-ID", description = "요청을 보낸 사용자의 고유 ID")
+            @RequestHeader("X-USER-ID") String loginId,
+            @RequestBody OrderV1Request.CreateOrder request
+    );
+
+    @Operation(
+            summary = "주문 목록 조회",
+            description = "로그인한 사용자의 전체 주문 목록을 조회한다."
+    )
+    @GetMapping
+    ApiResponse<List<OrderV1Response.OrderListItem>> getOrders(
+            @Parameter(name = "X-USER-ID", description = "요청을 보낸 사용자의 고유 ID")
+            @RequestHeader("X-USER-ID") String loginId
+    );
+
+    @Operation(
+            summary = "특정 주문 상세 조회",
+            description = "특정 주문에 대한 상세 정보를 조회한다."
+    )
+    @GetMapping("/{orderId}")
+    ApiResponse<OrderV1Response.OrderDetail> getOrderDetail(
+            @Parameter(name = "orderId", description = "조회할 주문의 고유 ID")
+            @PathVariable Long orderId
+    );
+
+    @Operation(
+            summary = "주문 취소",
+            description = "생성된 주문을 취소한다. 주문 취소 시 재고가 복구된다."
+    )
+    @PatchMapping("/{orderId}/cancel")
+    ApiResponse<OrderV1Response.CancelOrder> cancelOrder(
+            @Parameter(name = "X-USER-ID", description = "요청을 보낸 사용자의 고유 ID")
+            @RequestHeader("X-USER-ID") String loginId,
+            @Parameter(name = "orderId", description = "취소할 주문의 고유 ID")
+            @PathVariable Long orderId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderV1Request.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderV1Request.java
@@ -1,0 +1,23 @@
+package com.loopers.interfaces.api.controller.order;
+
+import java.util.List;
+
+public class OrderV1Request {
+
+    public record CreateOrder(
+            String loginId,
+            List<OrderItem> items
+    ) {
+
+    }
+    public record OrderItem(
+            Long productSkuId,
+            int quantity
+    ) {
+    }
+
+    public record CancelOrder(
+            String loginId,
+            Long orderId
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderV1Response.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/order/OrderV1Response.java
@@ -7,7 +7,7 @@ import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-public class OrderResponse {
+public class OrderV1Response {
 
     public record CreateOrder(
             Long orderId,
@@ -79,6 +79,22 @@ public class OrderResponse {
                     info.price(),
                     info.status().name(),
                     info.createdAt()
+            );
+        }
+    }
+
+    public record CancelOrder(
+            Long orderId,
+            Long userId,
+            String status,
+            ZonedDateTime updatedAt
+    ) {
+        public static CancelOrder from(OrderInfo.CancelOrder info) {
+            return new CancelOrder(
+                    info.orderId(),
+                    info.userId(),
+                    info.status().name(),
+                    info.updatedAt()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentController.java
@@ -1,0 +1,46 @@
+package com.loopers.interfaces.api.controller.payment;
+
+import com.loopers.application.payment.PaymentUsecase;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders/{orderId}/payments")
+public class PaymentController implements PaymentV1ApiSpec {
+
+    private final PaymentUsecase paymentUsecase;
+
+    @PostMapping
+    public ApiResponse<PaymentV1Response.CreatePayment> createPayment(
+            @PathVariable Long orderId,
+            @RequestBody PaymentV1Request.CreatePayment request
+    ) {
+        PaymentCommand.CreatePayment command = new PaymentCommand.CreatePayment(
+                request.loginId(),
+                orderId,
+                request.amount(),
+                request.method()
+        );
+
+        var paymentInfo = paymentUsecase.createPayment(command);
+        return ApiResponse.success(PaymentV1Response.CreatePayment.from(paymentInfo));
+    }
+
+    @DeleteMapping("/{paymentId}")
+    public ApiResponse<PaymentV1Response.CancelPayment> cancelPayment(
+            @PathVariable Long orderId,
+            @PathVariable Long paymentId,
+            @RequestBody PaymentV1Request.CancelPayment request
+    ) {
+        PaymentCommand.CancelPayment command = new PaymentCommand.CancelPayment(
+                request.loginId(),
+                orderId,
+                paymentId
+        );
+        var cancelInfo = paymentUsecase.cancelPayment(command);
+        return ApiResponse.success(PaymentV1Response.CancelPayment.from(cancelInfo));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentRequest.java
@@ -1,0 +1,9 @@
+package com.loopers.interfaces.api.controller.payment;
+
+public class PaymentRequest {
+    public record CreatePayment(
+            String loginId,
+            Long amount,
+            String method // "POINT" or "CREDIT"
+    ) {}
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentResponse.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.controller.payment;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentInfo;
+
+import java.time.ZonedDateTime;
+
+public class PaymentResponse {
+    public record CreatePayment(
+            Long paymentId,
+            Long userId,
+            Long orderId,
+            Long amount,
+            Payment.Method method,
+            Payment.Status status,
+            ZonedDateTime createdAt
+    ) {
+        public static CreatePayment from(PaymentInfo.CreatePayment info) {
+            return new CreatePayment(
+                    info.paymentId(),
+                    info.userId(),
+                    info.orderId(),
+                    info.amount(),
+                    info.method(),
+                    info.status(),
+                    info.createdAt()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1ApiSpec.java
@@ -1,0 +1,48 @@
+package com.loopers.interfaces.api.controller.payment;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Tag(name = "결제", description = "결제 생성 및 취소 관련 API")
+public interface PaymentV1ApiSpec {
+
+    @Operation(
+            summary = "결제 생성",
+            description = "특정 주문에 대한 결제 정보를 생성합니다."
+    )
+    @PostMapping("/api/v1/orders/{orderId}/payments")
+    ApiResponse<PaymentV1Response.CreatePayment> createPayment(
+            @Parameter(name = "orderId", description = "결제할 주문의 고유 ID")
+            @PathVariable Long orderId,
+            @RequestBody(
+                    description = "결제에 필요한 정보",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = PaymentV1Request.CreatePayment.class))
+            ) PaymentV1Request.CreatePayment request
+    );
+
+    @Operation(
+            summary = "결제 취소",
+            description = "특정 결제 건을 취소합니다. 결제 취소 시 해당 주문의 상태가 변경될 수 있습니다."
+    )
+    @DeleteMapping("/api/v1/orders/{orderId}/payments/{paymentId}")
+    ApiResponse<PaymentV1Response.CancelPayment> cancelPayment(
+            @Parameter(name = "orderId", description = "취소할 결제 건이 속한 주문의 고유 ID")
+            @PathVariable Long orderId,
+            @Parameter(name = "paymentId", description = "취소할 결제 건의 고유 ID")
+            @PathVariable Long paymentId,
+            @RequestBody(
+                    description = "결제 취소에 필요한 정보",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = PaymentV1Request.CancelPayment.class))
+            ) PaymentV1Request.CancelPayment request
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Request.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Request.java
@@ -1,9 +1,13 @@
 package com.loopers.interfaces.api.controller.payment;
 
-public class PaymentRequest {
+public class PaymentV1Request {
     public record CreatePayment(
             String loginId,
             Long amount,
-            String method // "POINT" or "CREDIT"
+            String method
+    ) {}
+
+    public record CancelPayment(
+            String loginId
     ) {}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Response.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Response.java
@@ -5,7 +5,7 @@ import com.loopers.domain.payment.PaymentInfo;
 
 import java.time.ZonedDateTime;
 
-public class PaymentResponse {
+public class PaymentV1Response {
     public record CreatePayment(
             Long paymentId,
             Long userId,
@@ -24,6 +24,26 @@ public class PaymentResponse {
                     info.method(),
                     info.status(),
                     info.createdAt()
+            );
+        }
+    }
+
+    public record CancelPayment(
+            Long paymentId,
+            Long orderId,
+            Long userId,
+            String method,
+            String status,
+            ZonedDateTime updatedAt
+    ) {
+        public static CancelPayment from(PaymentInfo.CancelPayment info) {
+            return new CancelPayment(
+                    info.paymentId(),
+                    info.orderId(),
+                    info.userId(),
+                    info.method().name(),
+                    info.status().name(),
+                    info.updatedAt()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/point/PointV1ApiSpec.java
@@ -2,30 +2,36 @@ package com.loopers.interfaces.api.controller.point;
 
 import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@Tag(name = "포인트", description = "포인트관련API")
+@Tag(name = "포인트", description = "포인트 충전 및 조회 관련 API")
 public interface PointV1ApiSpec {
 
     @Operation(
-            summary = "포인트충전",
-            description = "사용자의 포인트를 지정한 금액만큼 충전한다."
+            summary = "포인트 충전",
+            description = "사용자의 포인트를 충전합니다."
     )
     ApiResponse<PointV1Response> charge(
-            @Schema(name = "사용자정보", description = "사용자정보")
-            String loginId,
-            @Schema(name = "충전금액", description = "충전금액")
-            PointV1Request.Charge request
+            @Parameter(name = "X-USER-ID", description = "요청을 보낸 사용자의 고유 ID")
+            @RequestHeader("X-USER-ID") String loginId,
+            @RequestBody(
+                    description = "충전에 필요한 정보",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = PointV1Request.Charge.class))
+            ) PointV1Request.Charge request
     );
 
     @Operation(
-            summary = "포인트조회",
-            description = "사용자의 현재 보유 포인트를 조회한다."
+            summary = "나의 현재 포인트 조회",
+            description = "로그인한 사용자의 현재 보유 포인트를 조회합니다."
     )
     ApiResponse<PointV1Response> myPoint(
-            @Schema(name = "예시 ID", description = "조회할 예시의 ID")
-            @RequestHeader("X-User-Id") String userId
+            @Parameter(name = "X-USER-ID", description = "요청을 보낸 사용자의 고유 ID")
+            @RequestHeader("X-USER-ID") String loginId
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductController.java
@@ -1,0 +1,36 @@
+package com.loopers.interfaces.api.controller.product;
+
+import com.loopers.application.product.ProductUsecase;
+import com.loopers.domain.product.ProductInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/products")
+public class ProductController {
+
+    private final ProductUsecase productUsecase;
+
+    @GetMapping
+    public ApiResponse<ProductV1Response.Summaries> getProductSummaries(
+            @Valid ProductV1Request.List request
+    ) {
+        List<ProductInfo.Summary> infos = productUsecase.getProductSummaries(request.toCommand());
+        return ApiResponse.success(ProductV1Response.Summaries.from(infos));
+    }
+
+    @GetMapping("/{productId}")
+    public ApiResponse<ProductV1Response.Detail> getProductDetail(@PathVariable Long productId) {
+        ProductInfo.Detail detail = productUsecase.getProductDetail(productId);
+        return ApiResponse.success(ProductV1Response.Detail.from(detail));
+    }
+}
+

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductRequest.java
@@ -1,0 +1,24 @@
+package com.loopers.interfaces.api.controller.product;
+
+import com.loopers.domain.product.ProductCommand;
+import com.loopers.domain.product.ProductSortType;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public class ProductRequest{
+    public record List(
+            @PositiveOrZero Integer page,
+            @Positive Integer size,
+            Long brandId,
+            ProductSortType sortType
+    ) {
+        public ProductCommand.List toCommand() {
+            return new ProductCommand.List(
+                    page != null ? page : 0,
+                    size != null ? size : 5,
+                    brandId,
+                    sortType != null ? sortType : ProductSortType.RECENT
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductResponse.java
@@ -1,0 +1,81 @@
+package com.loopers.interfaces.api.controller.product;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductInfo;
+
+import java.util.List;
+
+public class ProductResponse{
+
+    public record Summaries(
+            long totalCount,
+            List<Summary> summaries
+    ) {
+        public static Summaries from(List<ProductInfo.Summary> infos) {
+            List<Summary> summaries = infos.stream()
+                    .map(Summary::from)
+                    .toList();
+            return new Summaries(infos.size(), summaries);
+        }
+    }
+
+    public record Summary(
+            Long id,
+            String name,
+            int price,
+            long likeCount,
+            String status
+    ) {
+        public static Summary from(ProductInfo.Summary info) {
+            return new Summary(
+                    info.id(),
+                    info.name(),
+                    info.price(),
+                    info.likeCount(),
+                    info.status()
+            );
+        }
+    }
+
+    public record Detail(
+            Long id,
+            String name,
+            Product.Status status,
+            Long brandId,
+            String brandName,
+            long likeCount,
+            List<Sku> skus
+    ) {
+        public static Detail from(ProductInfo.Detail info) {
+            return new Detail(
+                    info.id(),
+                    info.name(),
+                    info.status(),
+                    info.brandId(),
+                    info.brandName(),
+                    info.likeCount(),
+                    info.skus().stream().map(Sku::from).toList()
+            );
+        }
+    }
+
+    public record Sku(
+            Long id,
+            String sku,
+            int price,
+            int stockTotal,
+            int stockReserved
+    ) {
+        public static Sku from(ProductInfo.Sku info) {
+            return new Sku(
+                    info.id(),
+                    info.sku(),
+                    info.price(),
+                    info.stockTotal(),
+                    info.stockReserved()
+            );
+        }
+    }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductV1ApiSpec.java
@@ -1,0 +1,33 @@
+package com.loopers.interfaces.api.controller.product;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "상품", description = "상품 조회 관련 API")
+public interface ProductV1ApiSpec {
+
+    @Operation(
+            summary = "상품 요약 목록 조회",
+            description = "다양한 조건으로 상품 요약 정보를 목록 형태로 조회할 수 있습니다."
+    )
+    ApiResponse<ProductV1Response.Summaries> getProductSummaries(
+            @Valid ProductV1Request.List request
+    );
+
+    @Operation(
+            summary = "특정 상품 상세 조회",
+            description = "특정 상품의 상세 정보를 조회합니다."
+    )
+    ApiResponse<ProductV1Response.Detail> getProductDetail(
+            @Parameter(
+                    name = "productId",
+                    description = "조회할 상품의 고유 ID",
+                    example = "1"
+            )
+            @PathVariable Long productId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductV1Request.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductV1Request.java
@@ -5,7 +5,7 @@ import com.loopers.domain.product.ProductSortType;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
-public class ProductRequest{
+public class ProductV1Request {
     public record List(
             @PositiveOrZero Integer page,
             @Positive Integer size,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductV1Response.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/product/ProductV1Response.java
@@ -5,7 +5,7 @@ import com.loopers.domain.product.ProductInfo;
 
 import java.util.List;
 
-public class ProductResponse{
+public class ProductV1Response {
 
     public record Summaries(
             long totalCount,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/user/UserV1Request.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/user/UserV1Request.java
@@ -1,7 +1,7 @@
 package com.loopers.interfaces.api.controller.user;
 
+import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserCommand;
-import com.loopers.domain.user.UserEntity;
 import jakarta.validation.constraints.NotNull;
 
 public class UserV1Request {
@@ -10,7 +10,7 @@ public class UserV1Request {
             @NotNull
             String loginId,
             @NotNull
-            UserEntity.Gender gender,
+            User.Gender gender,
             @NotNull
             String name,
             @NotNull

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/user/UserV1Response.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/user/UserV1Response.java
@@ -1,12 +1,12 @@
 package com.loopers.interfaces.api.controller.user;
 
+import com.loopers.domain.user.User;
 import com.loopers.domain.user.UserInfo;
-import com.loopers.domain.user.UserEntity;
 
 public record UserV1Response(
         Long id,
         String loginId,
-        UserEntity.Gender gender,
+        User.Gender gender,
         String name,
         String birth,
         String email

--- a/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandApplicationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandApplicationServiceTest.java
@@ -2,7 +2,7 @@ package com.loopers.application.brand;
 
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.brand.BrandService;
-import com.loopers.interfaces.api.controller.brand.BrandResponse;
+import com.loopers.interfaces.api.controller.brand.BrandV1Response;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
@@ -37,7 +37,7 @@ class BrandApplicationServiceTest {
             Brand brand = Brand.create("나이키", "스포츠 브랜드");
             when(brandService.get(1L)).thenReturn(brand);
 
-            BrandResponse result = brandApplicationService.getBrandInfo(1L);
+            BrandV1Response result = brandApplicationService.getBrandInfo(1L);
 
             assertEquals("나이키", result.name());
             assertEquals("스포츠 브랜드", result.description());

--- a/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandApplicationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandApplicationServiceTest.java
@@ -1,0 +1,67 @@
+package com.loopers.application.brand;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.interfaces.api.controller.brand.BrandResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BrandApplicationService")
+class BrandApplicationServiceTest {
+
+    @Mock
+    private BrandService brandService;
+
+    @InjectMocks
+    private BrandApplicationService brandApplicationService;
+
+    @Nested
+    @DisplayName("[브랜드 정보 조회]")
+    class GetBrandInfo {
+
+        @Test
+        @DisplayName("[성공] 브랜드 정보를 조회하여 응답 객체로 변환한다.")
+        void success_getBrandInfo() {
+            Brand brand = Brand.create("나이키", "스포츠 브랜드");
+            when(brandService.get(1L)).thenReturn(brand);
+
+            BrandResponse result = brandApplicationService.getBrandInfo(1L);
+
+            assertEquals("나이키", result.name());
+            assertEquals("스포츠 브랜드", result.description());
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 브랜드일 경우 NOT_FOUND 예외가 발생한다.")
+        void failure_getBrandInfo_notFound() {
+            when(brandService.get(999L))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 브랜드입니다."));
+
+            CoreException ex = assertThrows(CoreException.class, () -> brandApplicationService.getBrandInfo(999L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 비활성화된 브랜드일 경우 BAD_REQUEST 예외가 발생한다.")
+        void failure_getBrandInfo_inactive() {
+            when(brandService.get(2L))
+                    .thenThrow(new CoreException(ErrorType.BAD_REQUEST, "비활성화된 브랜드입니다."));
+
+            CoreException ex = assertThrows(CoreException.class, () -> brandApplicationService.getBrandInfo(2L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeApplicationServiceUnitTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeApplicationServiceUnitTest.java
@@ -1,0 +1,161 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.*;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LikeApplicationService")
+class LikeApplicationServiceUnitTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private LikeValidator likeValidator;
+    @Mock
+    private LikeService likeService;
+    @Mock
+    private ProductService productService;
+
+    @InjectMocks
+    private LikeApplicationService likeApplicationService;
+
+    @Nested
+    @DisplayName("[좋아요 등록]")
+    class LikeProduct {
+
+        @Test
+        @DisplayName("[성공] 사용자가 상품에 좋아요를 등록한다.")
+        void success_likeProduct() {
+            LikeCommand.Like cmd = new LikeCommand.Like("loginId", 100L, LikeTargetType.PRODUCT);
+            User user = User.builder().id(1L).build();
+            Product product = Product.builder().id(100L).status(Product.Status.ACTIVE).build();
+
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productService.getProduct(100L)).thenReturn(product);
+
+            likeApplicationService.like(cmd);
+
+            verify(likeValidator).validateNotExists(1L, 100L, LikeTargetType.PRODUCT);
+            verify(likeService).save(1L, 100L, LikeTargetType.PRODUCT);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 사용자일 경우 NOT_FOUND 예외가 발생한다.")
+        void failure_likeProduct_whenUserNotFound() {
+            LikeCommand.Like cmd = new LikeCommand.Like("loginId", 100L, LikeTargetType.PRODUCT);
+            when(userService.getUser("loginId")).thenThrow(new CoreException(ErrorType.NOT_FOUND, "사용자 없음"));
+
+            CoreException ex = assertThrows(CoreException.class, () -> likeApplicationService.like(cmd));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 상품일 경우 NOT_FOUND 예외가 발생한다.")
+        void failure_likeProduct_whenProductNotFound() {
+            LikeCommand.Like cmd = new LikeCommand.Like("loginId", 100L, LikeTargetType.PRODUCT);
+            User user = User.builder().id(1L).build();
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productService.getProduct(100L)).thenThrow(new CoreException(ErrorType.NOT_FOUND, "상품 없음"));
+
+            CoreException ex = assertThrows(CoreException.class, () -> likeApplicationService.like(cmd));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 이미 좋아요한 상품일 경우 BAD_REQUEST 예외가 발생한다.")
+        void failure_likeProduct_whenAlreadyLiked() {
+            LikeCommand.Like cmd = new LikeCommand.Like("loginId", 100L, LikeTargetType.PRODUCT);
+            User user = User.builder().id(1L).build();
+            Product product = Product.builder().id(100L).status(Product.Status.ACTIVE).build();
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productService.getProduct(100L)).thenReturn(product);
+            doThrow(new CoreException(ErrorType.BAD_REQUEST, "이미 좋아요함"))
+                    .when(likeValidator).validateNotExists(1L, 100L, LikeTargetType.PRODUCT);
+
+            CoreException ex = assertThrows(CoreException.class, () -> likeApplicationService.like(cmd));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("[좋아요 취소]")
+    class UnLikeProduct {
+
+        @Test
+        @DisplayName("[성공] 사용자가 기존 좋아요를 취소한다.")
+        void success_unlikeProduct() {
+            LikeCommand.Like cmd = new LikeCommand.Like("loginId", 100L, LikeTargetType.PRODUCT);
+            User user = User.builder().id(1L).build();
+            Product product = Product.builder().id(100L).status(Product.Status.ACTIVE).build();
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productService.getProduct(100L)).thenReturn(product);
+
+            likeApplicationService.unlike(cmd);
+
+            verify(likeValidator).validateExists(1L, 100L, LikeTargetType.PRODUCT);
+            verify(likeService).delete(1L, 100L, LikeTargetType.PRODUCT);
+        }
+
+        @Test
+        @DisplayName("[실패] 좋아요하지 않은 상품일 경우 BAD_REQUEST 예외가 발생한다.")
+        void failure_unlikeProduct_whenNotLiked() {
+            LikeCommand.Like cmd = new LikeCommand.Like("loginId", 100L, LikeTargetType.PRODUCT);
+            User user = User.builder().id(1L).build();
+            Product product = Product.builder().id(100L).status(Product.Status.ACTIVE).build();
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productService.getProduct(100L)).thenReturn(product);
+            doThrow(new CoreException(ErrorType.BAD_REQUEST, "좋아요 없음"))
+                    .when(likeValidator).validateExists(1L, 100L, LikeTargetType.PRODUCT);
+
+            CoreException ex = assertThrows(CoreException.class, () -> likeApplicationService.unlike(cmd));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("[좋아요한 상품 목록 조회]")
+    class GetLikedProducts {
+
+        @Test
+        @DisplayName("[성공] 사용자가 좋아요한 상품 목록을 반환한다.")
+        void success_getLikedProducts() {
+            LikeCommand.LikedProducts cmd = new LikeCommand.LikedProducts("loginId", LikeTargetType.PRODUCT, 1,5);
+            User user = User.builder().id(1L).build();
+            LikedProduct p = new LikedProduct(1L, "상품", 1000, 3L, Product.Status.ACTIVE, null);
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(likeService.getLikedProducts(1L, 1, 5)).thenReturn(List.of(p));
+
+            List<LikeInfo.LikedProduct> result = likeApplicationService.getLikedProducts(cmd);
+            assertEquals(1, result.size());
+            assertEquals("상품", result.get(0).name());
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 사용자일 경우 NOT_FOUND 예외가 발생한다.")
+        void failure_getLikedProducts_whenUserNotFound() {
+            LikeCommand.LikedProducts cmd = new LikeCommand.LikedProducts("loginId", LikeTargetType.PRODUCT, 1,5);
+            when(userService.getUser("loginId")).thenThrow(new CoreException(ErrorType.NOT_FOUND, "사용자 없음"));
+
+            CoreException ex = assertThrows(CoreException.class, () -> likeApplicationService.getLikedProducts(cmd));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderApplicationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderApplicationServiceTest.java
@@ -1,0 +1,244 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderApplicationService")
+class OrderApplicationServiceTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private ProductSkuService productSkuService;
+    @Mock
+    private ProductService productService;
+    @Mock
+    private OrderService orderService;
+
+    @InjectMocks
+    private OrderApplicationService orderApplicationService;
+
+    @Nested
+    @DisplayName("[주문 생성]")
+    class CreateOrder {
+        @Test
+        @DisplayName("[성공] 정상적으로 주문을 생성한다.")
+        void success_order() {
+            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                    "loginId",
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2))
+            );
+            User user = User.builder().id(1L).build();
+            ProductSku sku = ProductSku.builder()
+                    .id(10L).price(1000).stockTotal(10).stockReserved(0)
+                    .product(Product.builder().id(100L).build())
+                    .build();
+            Order order = Order.create(user.getId(), 2000L);
+
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productSkuService.getBySkuId(10L)).thenReturn(sku);
+            when(orderService.saveOrder(any(Order.class))).thenReturn(order);
+
+            var result = orderApplicationService.order(cmd);
+
+            assertThat(result.price()).isEqualTo(2000L);
+            verify(productSkuService).reserveStock(sku, 2);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 사용자일 경우 NOT_FOUND 에러를 반환한다.")
+        void failure_userNotFound() {
+            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder("loginId", List.of());
+            when(userService.getUser("loginId"))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "사용자 없음"));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> orderApplicationService.order(cmd));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 상품 옵션 NOT_FOUND 에러를 반환한다.")
+        void failure_skuNotFound() {
+            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                    "loginId",
+                    List.of(new OrderCommand.OrderItemCommand(10L, 1))
+            );
+            User user = User.builder().id(1L).build();
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productSkuService.getBySkuId(10L))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "옵션 없음"));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> orderApplicationService.order(cmd));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 재고 부족할 경우 BAD_REQUEST 에러를 반환한다.")
+        void failure_insufficientStock() {
+            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                    "loginId",
+                    List.of(new OrderCommand.OrderItemCommand(10L, 5))
+            );
+            User user = User.builder().id(1L).build();
+            ProductSku sku = ProductSku.builder().id(10L).build();
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productSkuService.getBySkuId(10L)).thenReturn(sku);
+            doThrow(new CoreException(ErrorType.BAD_REQUEST, "재고 부족"))
+                    .when(productSkuService).reserveStock(sku, 5);
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> orderApplicationService.order(cmd));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("[성공] 모든 옵션이 품절이면 상품 상태를 SOLD_OUT으로 변경한다")
+        void success_updateProductStatusToSoldOut() {
+            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                    "loginId",
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2))
+            );
+
+            User user = User.builder().id(1L).build();
+
+            ProductSku sku = ProductSku.builder()
+                    .id(10L)
+                    .price(1000)
+                    .stockTotal(2)
+                    .stockReserved(0)
+                    .product(Product.builder().id(100L).status(Product.Status.ACTIVE).build())
+                    .build();
+
+            Order order = Order.create(user.getId(), 2000L);
+
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productSkuService.getBySkuId(10L)).thenReturn(sku);
+            when(productSkuService.isAllSoldOut(100L)).thenReturn(true);
+            when(orderService.saveOrder(any(Order.class))).thenReturn(order);
+
+            orderApplicationService.order(cmd);
+
+            verify(productService).updateStatus(true, 100L);
+        }
+
+        @Test
+        @DisplayName("[성공] 일부 옵션만 품절이면 상품 상태를 변경하지 않는다")
+        void success_doNotUpdateStatusWhenNotAllSoldOut() {
+            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                    "loginId",
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2))
+            );
+
+            User user = User.builder().id(1L).build();
+
+            ProductSku sku = ProductSku.builder()
+                    .id(10L)
+                    .price(1000)
+                    .stockTotal(5)
+                    .stockReserved(0)
+                    .product(Product.builder().id(100L).status(Product.Status.ACTIVE).build())
+                    .build();
+
+            Order order = Order.create(user.getId(), 2000L);
+
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(productSkuService.getBySkuId(10L)).thenReturn(sku);
+            when(productSkuService.isAllSoldOut(100L)).thenReturn(false);
+            when(orderService.saveOrder(any(Order.class))).thenReturn(order);
+
+            orderApplicationService.order(cmd);
+
+            verify(productService, never()).updateStatus(true, 100L);
+        }
+    }
+
+    @Nested
+    @DisplayName("[주문 목록 조회]")
+    class GetOrders {
+        @Test
+        @DisplayName("[성공] 사용자 주문 목록을 조회한다. ")
+        void success_getOrders() {
+            User user = User.builder().id(1L).build();
+            Order order = Order.create(user.getId(), 1000L);
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(orderService.getOrdersByUserId(1L)).thenReturn(List.of(order));
+
+            var result = orderApplicationService.getOrdersByUserId("loginId");
+
+            assertThat(result).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("[주문 상세 조회]")
+    class GetOrderDetail {
+        @Test
+        @DisplayName("[성공] 주문에 대한 상세정보를 조회한다. ")
+        void success_detail() {
+            Order order = Order.create(1L, 1000L);
+            when(orderService.getOrder(1L)).thenReturn(order);
+
+            var detail = orderApplicationService.getOrderDetail(1L);
+
+            assertThat(detail.price()).isEqualTo(1000L);
+        }
+
+        @Test
+        @DisplayName("주문 상세 조회 시 주문 항목 목록이 포함된다")
+        void success_detail_withOrderItems() {
+            Order order = Order.create(1L, 1000L);
+            order.addOrderItem(OrderItem.create(101L, 2));
+            order.addOrderItem(OrderItem.create(102L, 1));
+
+            when(orderService.getOrder(1L)).thenReturn(order);
+
+            var detail = orderApplicationService.getOrderDetail(1L);
+
+            assertThat(detail.items()).hasSize(2);
+            assertThat(detail.items().get(0).productSkuId()).isEqualTo(101L);
+            assertThat(detail.items().get(1).productSkuId()).isEqualTo(102L);
+        }
+
+        @Test
+        @DisplayName("[실패] 해당 주문이 없을경우 NOT_FOUND 에러를 반환한다. ")
+        void failure_notFound() {
+            when(orderService.getOrder(1L))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "주문 없음"));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> orderApplicationService.getOrderDetail(1L));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentApplicationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentApplicationServiceTest.java
@@ -1,0 +1,138 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.payment.PaymentInfo;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentApplicationService")
+public class PaymentApplicationServiceTest {
+
+    @Mock
+    private UserService userService;
+    @Mock
+    private OrderService orderService;
+    @Mock
+    private PaymentService paymentService;
+
+    @InjectMocks
+    private PaymentApplicationService paymentApplicationService;
+
+    @Nested
+    @DisplayName("[결제 요청]")
+    class CreatePayment {
+
+        @Test
+        @DisplayName("[성공] 결제를 정상 생성한다.")
+        void success_createPayment() {
+            PaymentCommand.CreatePayment cmd =
+                    new PaymentCommand.CreatePayment("loginId", 1L, 1000L, "POINT");
+
+            User user = User.builder().id(10L).point(5000L).build();
+            Order order = Order.create(user.getId(), 1000L);
+
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(orderService.getOrder(1L)).thenReturn(order);
+            Payment saved = Payment.create(user.getId(), order.getId(), 1000L, Payment.Method.POINT);
+            when(paymentService.save(any(Payment.class))).thenReturn(saved);
+
+            PaymentInfo.CreatePayment result = paymentApplicationService.createPayment(cmd);
+
+            assertThat(result.userId()).isEqualTo(10L);
+            assertThat(result.amount()).isEqualTo(1000L);
+            verify(userService).getUser("loginId");
+            verify(orderService).getOrder(1L);
+            verify(orderService).saveOrder(order);
+            verify(paymentService).save(any(Payment.class));
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 사용자로 결제 요청 시 NOT_FOUND 예외 발생")
+        void failure_userNotFound() {
+            PaymentCommand.CreatePayment cmd =
+                    new PaymentCommand.CreatePayment("loginId", 1L, 1000L, "POINT");
+            when(userService.getUser("loginId"))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "사용자 없음"));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> paymentApplicationService.createPayment(cmd));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 주문으로 결제 요청 시 NOT_FOUND 예외 발생")
+        void failure_orderNotFound() {
+            PaymentCommand.CreatePayment cmd =
+                    new PaymentCommand.CreatePayment("loginId", 1L, 1000L, "POINT");
+            User user = User.builder().id(10L).build();
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(orderService.getOrder(1L))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "주문 없음"));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> paymentApplicationService.createPayment(cmd));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 이미 결제된 주문 → CONFLICT")
+        void failure_orderAlreadyConfirmed() {
+            // given
+            PaymentCommand.CreatePayment cmd =
+                    new PaymentCommand.CreatePayment("loginId", 1L, 1000L, "POINT");
+            User user = User.builder().id(10L).build();
+            Order order = Order.create(user.getId(), 1000L);
+            order.confirm(); // 이미 결제됨
+
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(orderService.getOrder(1L)).thenReturn(order);
+
+            // when
+            IllegalStateException ex = assertThrows(IllegalStateException.class,
+                    () -> paymentApplicationService.createPayment(cmd));
+
+            // then
+            assertThat(ex.getMessage()).contains("이미 결제된 주문");
+        }
+
+        @Test
+        @DisplayName("[실패] 포인트 부족 → BAD_REQUEST")
+        void failure_insufficientPoint() {
+            PaymentCommand.CreatePayment cmd =
+                    new PaymentCommand.CreatePayment("loginId", 1L, 5000L, "POINT");
+            User user = User.builder().id(10L).point(1000L).build();
+            Order order = Order.create(user.getId(), 5000L);
+
+            when(userService.getUser("loginId")).thenReturn(user);
+            when(orderService.getOrder(1L)).thenReturn(order);
+
+            doThrow(new CoreException(ErrorType.BAD_REQUEST, "포인트 부족"))
+                    .when(paymentService).save(any(Payment.class));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> paymentApplicationService.createPayment(cmd));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductApplicationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductApplicationServiceTest.java
@@ -1,0 +1,184 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.brand.Brand;
+import com.loopers.domain.brand.BrandService;
+import com.loopers.domain.like.LikeService;
+import com.loopers.domain.like.LikeTargetType;
+import com.loopers.domain.product.*;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductApplicationService")
+class ProductApplicationServiceTest {
+
+    @Mock
+    private ProductService productService;
+    @Mock
+    private ProductSkuService productSkuService;
+    @Mock
+    private LikeService likeService;
+    @Mock
+    private BrandService brandService;
+
+    @InjectMocks
+    private ProductApplicationService productApplicationService;
+
+    @Nested
+    @DisplayName("[상품 목록 조회]")
+    class GetProductList {
+
+
+        static Stream<Arguments> providePagingAndSortOptions() {
+            return Stream.of(
+                    Arguments.of(0, 10, ProductSortType.RECENT),
+                    Arguments.of(1, 5, ProductSortType.RECENT),
+                    Arguments.of(0, 10, ProductSortType.LIKE),
+                    Arguments.of(1, 5, ProductSortType.LIKE),
+                    Arguments.of(0, 20, ProductSortType.LOW_PRICE)
+            );
+        }
+
+        @ParameterizedTest(name = "[성공] page={0}, size={1}, sortType={2} 조합으로 상품목록 조회")
+        @MethodSource("providePagingAndSortOptions")
+        void success_getProductSummaries_variousCases(int page, int size, ProductSortType sortType) {
+            ProductSummary summary = new ProductSummary(
+                    1L,
+                    "상품1",
+                    1000,
+                    3L,
+                    Product.Status.ACTIVE,
+                    LocalDateTime.now()
+            );
+
+            when(productService.getProductSummaries(any()))
+                    .thenReturn(List.of(summary));
+
+            var result = productApplicationService.getProductSummaries(
+                    new ProductCommand.List(page, size, 1L, sortType)
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).name()).isEqualTo("상품1");
+
+            verify(productService).getProductSummaries(any());
+        }
+
+        static Stream<Arguments> provideInvalidPaging() {
+            return Stream.of(
+                    Arguments.of(-1, 10),
+                    Arguments.of(0, 0),
+                    Arguments.of(0, -5)
+            );
+        }
+
+        @ParameterizedTest(name = "[실패] page={0}, size={1} 인 경우 BAD_REQUEST 발생")
+        @MethodSource("provideInvalidPaging")
+        void failure_invalidPaging(int page, int size) {
+            when(productService.getProductSummaries(any()))
+                    .thenThrow(new CoreException(ErrorType.BAD_REQUEST, "잘못된 페이징 요청"));
+
+            CoreException ex = assertThrows(CoreException.class, () ->
+                    productApplicationService.getProductSummaries(
+                            new ProductCommand.List(page, size, 1L, ProductSortType.RECENT)
+                    )
+            );
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("[상품 상세 조회]")
+    class GetProductDetail {
+
+        @Test
+        @DisplayName("[성공] 상품 상세 정보를 브랜드, 좋아요 수와 함께 조회한다.")
+        void success_getProductDetail() {
+            Product product = Product.builder()
+                    .id(1L)
+                    .brandId(2L)
+                    .name("상품1")
+                    .status(Product.Status.ACTIVE)
+                    .build();
+            ProductSku sku = ProductSku.builder()
+                    .id(10L)
+                    .product(product)
+                    .stockTotal(100)
+                    .stockReserved(0)
+                    .build();
+            Brand brand = Brand.builder()
+                    .id(2L)
+                    .name("브랜드A")
+                    .status(Brand.Status.ACTIVE)
+                    .build();
+
+            when(productService.getProduct(1L)).thenReturn(product);
+            when(productSkuService.getByProductId(1L)).thenReturn(List.of(sku));
+            when(likeService.getLikeCount(1L, LikeTargetType.PRODUCT)).thenReturn(5L);
+            when(brandService.get(2L)).thenReturn(brand);
+
+            var result = productApplicationService.getProductDetail(1L);
+
+            assertThat(result.name()).isEqualTo("상품1");
+            assertThat(result.brandName()).isEqualTo("브랜드A");
+            assertThat(result.likeCount()).isEqualTo(5L);
+
+            verify(productService).getProduct(1L);
+            verify(productSkuService).getByProductId(1L);
+            verify(likeService).getLikeCount(1L, LikeTargetType.PRODUCT);
+            verify(brandService).get(2L);
+        }
+
+        @Test
+        @DisplayName("[실패] 상품이 존재하지 않으면 NOT_FOUND 예외 발생")
+        void failure_getProductDetail_productNotFound() {
+            when(productService.getProduct(1L))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품"));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> productApplicationService.getProductDetail(1L));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 브랜드가 존재하지 않으면 NOT_FOUND 예외 발생")
+        void failure_getProductDetail_brandNotFound() {
+            Product product = Product.builder()
+                    .id(1L)
+                    .brandId(2L)
+                    .name("상품1")
+                    .status(Product.Status.ACTIVE)
+                    .build();
+
+            when(productService.getProduct(1L)).thenReturn(product);
+            when(brandService.get(2L))
+                    .thenThrow(new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 브랜드"));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> productApplicationService.getProductDetail(1L));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandEntityTest.java
@@ -1,0 +1,75 @@
+package com.loopers.domain.brand;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Brand Entity")
+class BrandEntityTest {
+
+    @Nested
+    @DisplayName("[브랜드 생성]")
+    class CreateBrand {
+
+        @Test
+        @DisplayName("[성공] 정상 값으로 브랜드를 생성한다.")
+        void success_createBrand() {
+            Brand brand = Brand.create("나이키", "스포츠 브랜드");
+
+            assertEquals("나이키", brand.getName());
+            assertEquals("스포츠 브랜드", brand.getDescription());
+            assertEquals(Brand.Status.ACTIVE, brand.getStatus());
+        }
+
+        @Test
+        @DisplayName("[성공] create() 호출 시 상태는 무조건 ACTIVE로 설정된다.")
+        void success_createBrand_forceActive() {
+            Brand brand = Brand.create("아디다스", "스포츠 브랜드");
+            assertEquals(Brand.Status.ACTIVE, brand.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("[활성 상태 확인]")
+    class IsActive {
+
+        @Test
+        @DisplayName("[성공] ACTIVE 상태이면 true를 반환한다.")
+        void success_isActive_true() {
+            Brand brand = Brand.builder()
+                    .name("나이키")
+                    .status(Brand.Status.ACTIVE)
+                    .build();
+
+            assertTrue(brand.isActive());
+        }
+
+        @Test
+        @DisplayName("[성공] INACTIVE 상태이면 false를 반환한다.")
+        void success_isActive_false() {
+            Brand brand = Brand.builder()
+                    .name("나이키")
+                    .status(Brand.Status.INACTIVE)
+                    .build();
+
+            assertFalse(brand.isActive());
+        }
+    }
+
+    @Nested
+    @DisplayName("[브랜드 비활성화]")
+    class Deactivate {
+
+        @Test
+        @DisplayName("[성공] 브랜드 상태를 INACTIVE로 변경한다.")
+        void success_deactivate() {
+            Brand brand = Brand.create("나이키", "스포츠 브랜드");
+            brand.deactivate();
+
+            assertEquals(Brand.Status.INACTIVE, brand.getStatus());
+            assertFalse(brand.isActive());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/brand/BrandServiceTest.java
@@ -1,0 +1,68 @@
+package com.loopers.domain.brand;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BrandService")
+class BrandServiceTest {
+
+    @Mock
+    private BrandRepository brandRepository;
+
+    @InjectMocks
+    private BrandService brandService;
+
+    @Nested
+    @DisplayName("[브랜드 조회]")
+    class GetBrand {
+
+        @Test
+        @DisplayName("[성공] 존재하는 활성화된 브랜드를 조회한다.")
+        void success_getBrand() {
+            Brand brand = Brand.create("나이키", "스포츠 브랜드");
+            when(brandRepository.findById(1L)).thenReturn(Optional.of(brand));
+
+            Brand result = brandService.get(1L);
+
+            assertEquals("나이키", result.getName());
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 브랜드 ID일 경우 NOT_FOUND 예외가 발생한다.")
+        void failure_getBrand_notFound() {
+            when(brandRepository.findById(999L)).thenReturn(Optional.empty());
+
+            CoreException ex = assertThrows(CoreException.class, () -> brandService.get(999L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 비활성화된 브랜드일 경우 BAD_REQUEST 예외가 발생한다.")
+        void failure_getBrand_inactive() {
+            Brand brand = Brand.builder()
+                    .name("아디다스")
+                    .status(Brand.Status.INACTIVE)
+                    .build();
+
+            when(brandRepository.findById(2L)).thenReturn(Optional.of(brand));
+
+            CoreException ex = assertThrows(CoreException.class, () -> brandService.get(2L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeEntityTest.java
@@ -1,0 +1,74 @@
+package com.loopers.domain.like;
+
+import com.loopers.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Like Entity")
+class LikeEntityTest {
+
+    @Nested
+    @DisplayName("[Like 생성]")
+    class CreateLike {
+
+        @Test
+        @DisplayName("[성공] 정상적인 정보로 Like를 생성한다.")
+        void success_createLike() {
+            Like like = Like.create(1L, 100L, LikeTargetType.PRODUCT);
+
+            assertEquals(1L, like.getUserId());
+            assertEquals(100L, like.getTargetId());
+            assertEquals(LikeTargetType.PRODUCT, like.getTargetType());
+        }
+    }
+
+    @Nested
+    @DisplayName("[타겟 일치 여부 확인]")
+    class IsTargetOf {
+
+        @Test
+        @DisplayName("[성공] 타겟 ID와 타입이 모두 일치하면 true를 반환한다.")
+        void success_isTargetOf() {
+            Like like = Like.create(1L, 100L, LikeTargetType.PRODUCT);
+
+            assertTrue(like.isTargetOf(100L, LikeTargetType.PRODUCT));
+        }
+
+        @Test
+        @DisplayName("[실패] 타겟 ID 또는 타입이 다르면 false를 반환한다.")
+        void failure_isTargetOf_whenDifferent() {
+            Like like = Like.create(1L, 100L, LikeTargetType.PRODUCT);
+
+            assertFalse(like.isTargetOf(101L, LikeTargetType.PRODUCT));
+            assertFalse(like.isTargetOf(100L, LikeTargetType.BRAND));
+        }
+    }
+
+    @Nested
+    @DisplayName("[동일 사용자 여부 확인]")
+    class IsSameUser {
+
+        @Test
+        @DisplayName("[성공] 동일한 사용자일 경우 true를 반환한다.")
+        void success_isSameUser() {
+            User user = User.builder().id(1L).build();
+            Like like = Like.create(1L, 100L, LikeTargetType.PRODUCT);
+
+            assertTrue(like.isSameUser(user));
+        }
+
+        @Test
+        @DisplayName("[실패] 다른 사용자일 경우 false를 반환한다.")
+        void failure_isSameUser_whenDifferentUser() {
+            User user = User.builder().id(2L).build();
+            Like like = Like.create(1L, 100L, LikeTargetType.PRODUCT);
+
+            assertFalse(like.isSameUser(user));
+        }
+    }
+}
+
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceUnitTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceUnitTest.java
@@ -1,0 +1,118 @@
+package com.loopers.domain.like;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LikeService")
+class LikeServiceUnitTest {
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Nested
+    @DisplayName("[좋아요 저장]")
+    class SaveLike {
+
+        @Test
+        @DisplayName("[성공] 사용자가 상품에 좋아요를 저장한다.")
+        void success_saveLike() {
+            likeService.save(1L, 100L, LikeTargetType.PRODUCT);
+            verify(likeRepository).save(any(Like.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("[좋아요 삭제]")
+    class DeleteLike {
+
+        @Test
+        @DisplayName("[성공] 사용자가 기존 좋아요를 삭제한다.")
+        void success_deleteLike() {
+            Like like = Like.create(1L, 100L, LikeTargetType.PRODUCT);
+            when(likeRepository.findLike(1L, 100L, LikeTargetType.PRODUCT)).thenReturn(Optional.of(like));
+
+            likeService.delete(1L, 100L, LikeTargetType.PRODUCT);
+            verify(likeRepository).delete(like);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 좋아요일 경우 BAD_REQUEST 예외가 발생한다.")
+        void failure_deleteLike_whenLikeDoesNotExist() {
+            when(likeRepository.findLike(1L, 100L, LikeTargetType.PRODUCT)).thenReturn(Optional.empty());
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> likeService.delete(1L, 100L, LikeTargetType.PRODUCT));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("[좋아요 개수 조회]")
+    class GetLikeCount {
+
+        @Test
+        @DisplayName("[조회 성공] 상품의 좋아요 개수를 반환한다.")
+        void success_getLikeCount() {
+            when(likeRepository.countByTargetId(100L, LikeTargetType.PRODUCT)).thenReturn(5L);
+
+            long count = likeService.getLikeCount(100L, LikeTargetType.PRODUCT);
+            assertEquals(5L, count);
+        }
+    }
+
+    @Nested
+    @DisplayName("[좋아요한 상품 목록 조회]")
+    class GetLikedProducts {
+
+        @Test
+        @DisplayName("[조회 성공] size=5, page=2일 경우 offset=10을 사용하여 상품을 조회한다.")
+        void success_getLikedProducts_customPageSize() {
+            LikedProductProjection projection = mock(LikedProductProjection.class);
+            when(projection.getId()).thenReturn(21L);
+            when(projection.getName()).thenReturn("상품21");
+
+            // page=2, size=5 → offset = 10
+            when(likeRepository.findLikedProducts(1L, 10, 5))
+                    .thenReturn(List.of(projection));
+
+            List<LikedProduct> result = likeService.getLikedProducts(1L, 2, 5);
+
+            assertEquals(1, result.size());
+            assertEquals("상품21", result.get(0).name());
+        }
+
+        @Test
+        @DisplayName("[조회 성공] 좋아요한 상품이 없을 경우 빈 리스트를 반환한다.")
+        void success_getLikedProducts_emptyList() {
+            when(likeRepository.findLikedProducts(1L, 0, 10))
+                    .thenReturn(Collections.emptyList());
+
+            List<LikedProduct> result = likeService.getLikedProducts(1L, 0, 10);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+}
+//실패케이스랑 test 할때 parameterizedTest 같은거써서 한번에 여러개의 값을 사용하는거,,,

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeValidatorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeValidatorTest.java
@@ -1,0 +1,78 @@
+package com.loopers.domain.like;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LikeValidator")
+class LikeValidatorTest {
+
+    @Mock
+    private LikeRepository likeRepository;
+
+    @InjectMocks
+    private LikeValidator likeValidator;
+
+    @Nested
+    @DisplayName("[좋아요 없음 검증]")
+    class ValidateNotExists {
+
+        @Test
+        @DisplayName("[성공] 좋아요가 존재하지 않으면 예외가 발생하지 않는다.")
+        void success_validateNotExists() {
+            when(likeRepository.findLike(1L, 100L, LikeTargetType.PRODUCT)).thenReturn(Optional.empty());
+            assertDoesNotThrow(() -> likeValidator.validateNotExists(1L, 100L, LikeTargetType.PRODUCT));
+        }
+
+        @Test
+        @DisplayName("[실패] 이미 좋아요한 상품일 경우 BAD_REQUEST 예외가 발생한다.")
+        void failure_validateNotExists_whenAlreadyLiked() {
+            when(likeRepository.findLike(1L, 100L, LikeTargetType.PRODUCT))
+                    .thenReturn(Optional.of(Like.create(1L, 100L, LikeTargetType.PRODUCT)));
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> likeValidator.validateNotExists(1L, 100L, LikeTargetType.PRODUCT));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("[좋아요 존재 검증]")
+    class ValidateExists {
+
+        @Test
+        @DisplayName("[성공] 좋아요가 존재하면 예외가 발생하지 않는다.")
+        void success_validateExists() {
+            when(likeRepository.findLike(1L, 100L, LikeTargetType.PRODUCT))
+                    .thenReturn(Optional.of(Like.create(1L, 100L, LikeTargetType.PRODUCT)));
+
+            assertDoesNotThrow(() -> likeValidator.validateExists(1L, 100L, LikeTargetType.PRODUCT));
+        }
+
+        @Test
+        @DisplayName("[실패] 좋아요가 존재하지 않으면 BAD_REQUEST 예외가 발생한다.")
+        void failure_validateExists_whenNotLiked() {
+            when(likeRepository.findLike(1L, 100L, LikeTargetType.PRODUCT)).thenReturn(Optional.empty());
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> likeValidator.validateExists(1L, 100L, LikeTargetType.PRODUCT));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderEntityTest.java
@@ -1,0 +1,79 @@
+package com.loopers.domain.order;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("Order")
+class OrderEntityTest {
+
+    @Nested
+    @DisplayName("[주문 생성 및 항목 추가]")
+    class CreateAndAddItems {
+
+        @Test
+        @DisplayName("[성공] 주문 생성 시 상태는 PENDING, 가격은 0")
+        void success_createOrder() {
+            Order order = Order.create(1L, 0L);
+            assertThat(order.getStatus()).isEqualTo(Order.Status.PENDING);
+            assertThat(order.getPrice()).isZero();
+        }
+
+        @Test
+        @DisplayName("[성공] 주문 항목 추가 시 OrderItem에 Order 설정됨")
+        void success_addOrderItem() {
+            Order order = Order.create(1L, 0L);
+            OrderItem item = OrderItem.create(10L, 2);
+
+            order.addOrderItem(item);
+
+            assertThat(order.getOrderItems()).containsExactly(item);
+            assertThat(item.getOrder()).isEqualTo(order);
+        }
+    }
+
+    @Nested
+    @DisplayName("[주문 취소]")
+    class Cancel {
+
+        @Test
+        @DisplayName("[성공] PENDING 상태에서 취소하면 상태가 CANCELED")
+        void success_cancel() {
+            Order order = Order.create(1L, 1000L);
+            order.cancel();
+            assertThat(order.getStatus()).isEqualTo(Order.Status.CANCELED);
+        }
+
+        @Test
+        @DisplayName("[실패] 이미 취소된 주문 취소 시 예외 발생")
+        void failure_cancelAlreadyCancelled() {
+            Order order = Order.create(1L, 1000L);
+            order.cancel();
+            assertThrows(IllegalStateException.class, order::cancel);
+        }
+    }
+
+    @Nested
+    @DisplayName("[주문 확정]")
+    class Confirm {
+
+        @Test
+        @DisplayName("[성공] PENDING 상태에서 확정하면 CONFIRMED")
+        void success_confirm() {
+            Order order = Order.create(1L, 1000L);
+            order.confirm();
+            assertThat(order.getStatus()).isEqualTo(Order.Status.CONFIRMED);
+        }
+
+        @Test
+        @DisplayName("[실패] CONFIRMED 상태에서 확정 시 예외")
+        void failure_confirmAlreadyConfirmed() {
+            Order order = Order.create(1L, 1000L);
+            order.confirm();
+            assertThrows(IllegalStateException.class, order::confirm);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceTest.java
@@ -1,0 +1,95 @@
+package com.loopers.domain.order;
+
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderService")
+class OrderServiceTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @Nested
+    @DisplayName("[주문 생성]")
+    class SaveOrder {
+        @Test
+        @DisplayName("[성공] 주문을 생성한다. ")
+        void success_saveOrder() {
+            Order order = Order.create(1L, 1000L);
+            when(orderRepository.save(order)).thenReturn(order);
+
+            Order saved = orderService.saveOrder(order);
+
+            assertThat(saved).isEqualTo(order);
+            verify(orderRepository).save(order);
+        }
+    }
+
+    @Nested
+    @DisplayName("[주문 단건 조회]")
+    class GetOrder {
+
+        @Test
+        @DisplayName("주문과 함께 주문 항목 목록을 조회한다")
+        void success_getOrder_withOrderItems() {
+            Order order = Order.create(1L, 1000L);
+            OrderItem item1 = OrderItem.create(101L, 2);
+            OrderItem item2 = OrderItem.create(102L, 1);
+            order.addOrderItem(item1);
+            order.addOrderItem(item2);
+
+            when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+
+            Order found = orderService.getOrder(1L);
+
+            assertThat(found.getOrderItems()).hasSize(2);
+            assertThat(found.getOrderItems().get(0).getProductSkuId()).isEqualTo(101L);
+            assertThat(found.getOrderItems().get(1).getProductSkuId()).isEqualTo(102L);
+        }
+
+        @Test
+        @DisplayName("[실패] 주문이 존재하지 않으면 NOT_FOUND 에러를 반환한다. ")
+        void failure_orderNotFound() {
+            when(orderRepository.findById(1L)).thenReturn(Optional.empty());
+
+            CoreException ex = assertThrows(CoreException.class,
+                    () -> orderService.getOrder(1L));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("[주문 목록 조회]")
+    class GetOrdersByUser {
+        @Test
+        @DisplayName("[성공] 해당 사용자의 주문목록을 조회한다. ")
+        void success_getOrdersByUser() {
+            Order order = Order.create(1L, 1000L);
+            when(orderRepository.findByUserId(1L)).thenReturn(List.of(order));
+
+            List<Order> result = orderService.getOrdersByUserId(1L);
+
+            assertThat(result).hasSize(1);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentServiceTest.java
@@ -1,0 +1,62 @@
+package com.loopers.domain.payment;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentService")
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Nested
+    @DisplayName("[결제 저장]")
+    class Save {
+
+        @Test
+        @DisplayName("[성공] 결제를 저장하고 저장된 엔티티를 반환한다.")
+        void success_savePayment() {
+            Payment payment = Payment.create(1L, 1L, 1000L, Payment.Method.POINT);
+            when(paymentRepository.save(payment)).thenReturn(payment);
+
+            Payment result = paymentService.save(payment);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getAmount()).isEqualTo(1000L);
+            assertThat(result.getMethod()).isEqualTo(Payment.Method.POINT);
+
+            verify(paymentRepository).save(payment);
+        }
+
+        @Test
+        @DisplayName("[실패] 저장 과정에서 예외가 발생하면 INTERNAL_ERROR 에러를 반환한다.")
+        void failure_savePayment_repositoryThrows() {
+            Payment payment = Payment.create(1L, 1L, 1000L, Payment.Method.POINT);
+            when(paymentRepository.save(payment))
+                    .thenThrow(new CoreException(ErrorType.INTERNAL_ERROR, "저장 실패"));
+
+            CoreException ex = assertThrows(CoreException.class, () -> paymentService.save(payment));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.INTERNAL_ERROR);
+            verify(paymentRepository).save(payment);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
@@ -1,0 +1,45 @@
+package com.loopers.domain.payment;
+
+import com.loopers.support.error.CoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("Payment")
+class PaymentTest {
+
+    @Nested
+    @DisplayName("[결제 생성]")
+    class Create {
+        @Test
+        @DisplayName("[성공] 결제를 생성하면 상태는 PAID이다.")
+        void success_createPayment() {
+            Payment p = Payment.create(1L, 1L, 1000L, Payment.Method.POINT);
+            assertThat(p.getStatus()).isEqualTo(Payment.Status.PAID);
+            assertThat(p.getAmount()).isEqualTo(1000L);
+        }
+    }
+
+    @Nested
+    @DisplayName("[결제 취소]")
+    class Cancel {
+        @Test
+        @DisplayName("[성공] 결제를 취소하면 상태가 CANCELLED로 변경된다.")
+        void success_cancel() {
+            Payment p = Payment.create(1L, 1L, 1000L, Payment.Method.POINT);
+            p.cancel();
+            assertThat(p.getStatus()).isEqualTo(Payment.Status.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("[실패] 이미 취소된 결제를 다시 취소하면 예외 발생")
+        void failure_cancelAlreadyCancelled() {
+            Payment p = Payment.create(1L, 1L, 1000L, Payment.Method.POINT);
+            p.cancel();
+            assertThrows(CoreException.class, p::cancel);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointIntegrationTest.java
@@ -71,9 +71,9 @@ class PointIntegrationTest {
         @Test
         void success_myPoint_whenUserExists() {
             // arrange
-            UserEntity user = new UserEntity(
+            User user = new User(
                     "loginId123",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "loginId123@user.com",

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointIntegrationTest.java
@@ -37,7 +37,6 @@ class PointIntegrationTest {
     @AfterEach
     void tearDown(){
         databaseCleanUp.truncateAllTables();
-        Mockito.reset(userRepository);
     }
 
     @DisplayName("[포인트 충전] ")
@@ -56,10 +55,7 @@ class PointIntegrationTest {
             );
 
             // assert
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
-
-            verify(userRepository).findByLoginId(command.loginId());
-            verify(userRepository, never()).save(any());
+            assertThat(userRepository.findByLoginId(command.loginId())).isEmpty();
         }
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointUnitTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointUnitTest.java
@@ -1,11 +1,10 @@
 package com.loopers.domain.point;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -23,9 +22,9 @@ class PointUnitTest {
         @ValueSource(longs = {0, -1000})
         void failure_charge_whenAmountIsZeroOrNegative(Long amount) {
 
-            UserEntity user = new UserEntity(
+            User user = new User(
                     "loginid",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "xx@yy.zz"

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductEntityTest.java
@@ -1,0 +1,82 @@
+package com.loopers.domain.product;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Product Entity")
+class ProductEntityTest {
+
+    @Nested
+    @DisplayName("[상품 생성]")
+    class CreateProduct {
+
+        @Test
+        @DisplayName("[성공] 정상 값으로 상품을 생성한다.")
+        void success_createProduct() {
+            Product product = Product.create("테스트 상품", Product.Status.ACTIVE, 10L);
+
+            assertEquals("테스트 상품", product.getName());
+            assertEquals(Product.Status.ACTIVE, product.getStatus());
+            assertEquals(10L, product.getBrandId());
+        }
+
+        @Test
+        @DisplayName("[성공] create() 팩토리 메서드는 상태를 무조건 ACTIVE로 설정한다.")
+        void success_createProduct_forceActive() {
+            Product product = Product.create("테스트 상품", Product.Status.SOLD_OUT, 10L);
+
+            assertEquals(Product.Status.ACTIVE, product.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("[판매 가능 여부 확인]")
+    class IsAvailable {
+
+        @Test
+        @DisplayName("[성공] ACTIVE 상태일 경우 판매 가능하다.")
+        void success_isAvailable_active() {
+            Product product = Product.builder()
+                    .name("상품")
+                    .status(Product.Status.ACTIVE)
+                    .brandId(10L)
+                    .build();
+
+            assertTrue(product.isAvailable());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = Product.Status.class, names = {"INACTIVE", "SOLD_OUT"})
+        @DisplayName("[성공] INACTIVE 또는 SOLD_OUT 상태일 경우 판매 불가하다.")
+        void success_isAvailable_false(Product.Status status) {
+            Product product = Product.builder()
+                    .name("상품")
+                    .status(status)
+                    .brandId(10L)
+                    .build();
+
+            assertFalse(product.isAvailable());
+        }
+    }
+
+    @Nested
+    @DisplayName("[상태 변경]")
+    class ChangeStatus {
+
+        @Test
+        @DisplayName("[성공] 상품 상태를 변경한다.")
+        void success_changeStatus() {
+            Product product = Product.create("상품", Product.Status.ACTIVE, 10L);
+
+            product.changeStatus(Product.Status.SOLD_OUT);
+
+            assertEquals(Product.Status.SOLD_OUT, product.getStatus());
+        }
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceTest.java
@@ -1,0 +1,173 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductService")
+class ProductServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductService productService;
+
+    @Nested
+    @DisplayName("[상품 목록 조회]")
+    class GetProductSummaries {
+
+        @Test
+        @DisplayName("[성공] 첫 페이지(page=0, size=10) 최신순 조회")
+        void success_firstPage_latestSort() {
+            ProductSummaryProjection projection = mock(ProductSummaryProjection.class);
+            when(projection.getId()).thenReturn(1L);
+            when(projection.getName()).thenReturn("상품1");
+            when(projection.getMinPrice()).thenReturn(1000);
+            when(projection.getLikeCount()).thenReturn(5L);
+            when(projection.getStatus()).thenReturn(Product.Status.ACTIVE);
+            when(projection.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            when(productRepository.findProductSummaries(1L, ProductSortType.RECENT, 1, 10))
+                    .thenReturn(List.of(projection));
+
+            var result = productService.getProductSummaries(
+                    new ProductCommand.List(1, 10, 1L, ProductSortType.RECENT)
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).name()).isEqualTo("상품1");
+        }
+
+        @Test
+        @DisplayName("[성공] 두 번째 페이지(page=1, size=5) 좋아요순 조회")
+        void success_secondPage_likesDesc() {
+            ProductSummaryProjection projection = mock(ProductSummaryProjection.class);
+            when(projection.getId()).thenReturn(6L);
+            when(projection.getName()).thenReturn("상품6");
+            when(projection.getMinPrice()).thenReturn(2000);
+            when(projection.getLikeCount()).thenReturn(10L);
+            when(projection.getStatus()).thenReturn(Product.Status.ACTIVE);
+            when(projection.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+            when(productRepository.findProductSummaries(1L, ProductSortType.LIKE, 1, 5))
+                    .thenReturn(List.of(projection));
+
+            var result = productService.getProductSummaries(
+                    new ProductCommand.List(1, 5, 1L, ProductSortType.LIKE)
+            );
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).id()).isEqualTo(6L);
+        }
+
+        @Test
+        @DisplayName("[경계값] size=0이면 빈 목록 반환 (또는 예외 처리)")
+        void boundary_zeroSize() {
+            when(productRepository.findProductSummaries(any(), any(), anyInt(), eq(0)))
+                    .thenReturn(List.of());
+
+            var result = productService.getProductSummaries(
+                    new ProductCommand.List(1, 0, 1L, ProductSortType.RECENT)
+            );
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("[단일 상품 조회]")
+    class GetProduct {
+
+        @Test
+        @DisplayName("[성공] 판매중인 상품을 조회한다.")
+        void success_getActiveProduct() {
+            Product product = Product.builder()
+                    .id(1L)
+                    .status(Product.Status.ACTIVE)
+                    .build();
+
+            when(productRepository.findBy(1L)).thenReturn(Optional.of(product));
+
+            Product result = productService.getProduct(1L);
+
+            assertThat(result.getId()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 상품일 경우 NOT_FOUND 예외 발생")
+        void failure_notFound() {
+            when(productRepository.findBy(999L)).thenReturn(Optional.empty());
+
+            CoreException ex = assertThrows(CoreException.class, () -> productService.getProduct(999L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 판매중이 아닌 상품일 경우 BAD_REQUEST 예외 발생")
+        void failure_inactiveProduct() {
+            Product product = Product.builder()
+                    .id(2L)
+                    .status(Product.Status.SOLD_OUT)
+                    .build();
+
+            when(productRepository.findBy(2L)).thenReturn(Optional.of(product));
+
+            CoreException ex = assertThrows(CoreException.class, () -> productService.getProduct(2L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("[상품 상태 업데이트]")
+    class UpdateStatus {
+
+        @Test
+        @DisplayName("[성공] 모든 재고가 소진된 경우 상품 상태를 SOLD_OUT으로 변경한다.")
+        void success_updateStatus_soldOut() {
+            Product product = Product.builder()
+                    .id(1L)
+                    .status(Product.Status.ACTIVE)
+                    .build();
+
+            when(productRepository.findBy(1L)).thenReturn(Optional.of(product));
+
+            productService.updateStatus(true, 1L);
+
+            assertThat(product.getStatus()).isEqualTo(Product.Status.SOLD_OUT);
+            verify(productRepository).saveProduct(product);
+        }
+
+        @Test
+        @DisplayName("[성공] 재고가 남아 있는 경우 상태 변경하지 않는다.")
+        void success_updateStatus_stockAvailable() {
+            productService.updateStatus(false, 1L);
+            verify(productRepository, never()).saveProduct(any());
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 상품 ID일 경우 NOT_FOUND 예외 발생")
+        void failure_updateStatus_notFound() {
+            when(productRepository.findBy(999L)).thenReturn(Optional.empty());
+
+            CoreException ex = assertThrows(CoreException.class, () -> productService.updateStatus(true, 999L));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductSkuEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductSkuEntityTest.java
@@ -1,0 +1,53 @@
+package com.loopers.domain.product;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ProductSku Entity")
+class ProductSkuEntityTest {
+
+    @Nested
+    @DisplayName("[재고 차감]")
+    class DecreaseStock {
+
+        @Test
+        @DisplayName("[성공] 재고를 정상적으로 차감한다.")
+        void success_decreaseStock() {
+            ProductSku sku = ProductSku.builder().stockTotal(10).stockReserved(0).build();
+            sku.reserveStock(3);
+            assertEquals(7, sku.avaliableQunatity());
+        }
+
+        @Test
+        @DisplayName("[성공] 재고를 딱 맞게 차감하면 가용재고가 0이 된다.")
+        void success_decreaseStock_exact() {
+            ProductSku sku = ProductSku.builder().stockTotal(5).stockReserved(0).build();
+            sku.reserveStock(5);
+            assertEquals(0, sku.avaliableQunatity());
+        }
+
+        @Test
+        @DisplayName("[실패] 재고보다 많은 수량을 차감하려고 하면 BAD_REQUEST 예외가 발생한다.")
+        void failure_decreaseStock_insufficient() {
+            ProductSku sku = ProductSku.builder().stockTotal(5).stockReserved(0).build();
+            CoreException ex = assertThrows(CoreException.class, () -> sku.reserveStock(6));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("[실패] 차감 후 음수가 되면 BAD_REQUEST 예외가 발생한다.")
+        void failure_decreaseStock_negative() {
+            ProductSku sku = ProductSku.builder().stockTotal(0).stockReserved(0).build();
+            CoreException ex = assertThrows(CoreException.class, () -> sku.reserveStock(1));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductSkuServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductSkuServiceTest.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.product;
+
+import com.loopers.infrastructure.product.ProductSkuJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProductSkuService")
+class ProductSkuServiceTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductSkuService productSkuService;
+
+    @Nested
+    @DisplayName("[재고 차감]")
+    class DecreaseStock {
+
+        @Test
+        @DisplayName("[성공] SKU 재고를 정상적으로 차감한다.")
+        void success_decreaseStock() {
+            ProductSku sku = ProductSku.builder().id(1L).stockTotal(5).stockReserved(0).build();
+
+            productSkuService.reserveStock(sku, 3);
+
+            assertEquals(2, sku.avaliableQunatity());
+            verify(productRepository).saveProductSku(sku);
+        }
+
+
+        @Test
+        @DisplayName("[성공] 재고를 딱 맞게 차감하면 재고가 0이 된다.")
+        void success_decreaseStock_exact() {
+            ProductSku sku = ProductSku.builder()
+                    .id(1L)
+                    .stockTotal(5)
+                    .stockReserved(0)
+                    .build();
+
+            productSkuService.reserveStock(sku, 5);
+
+            assertEquals(0, sku.avaliableQunatity());
+            verify(productRepository).saveProductSku(sku);
+        }
+
+        @Test
+        @DisplayName("[실패] 존재하지 않는 SKU일 경우 NOT_FOUND 예외가 발생한다.")
+        void failure_decreaseStock_skuNotFound() {
+            when(productRepository.findBySkuId(1L)).thenReturn(Optional.empty());
+
+            CoreException ex = assertThrows(CoreException.class, () -> productSkuService.getBySkuId(1L));
+
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("[실패] 재고 부족 시 BAD_REQUEST 예외가 발생한다.")
+        void failure_decreaseStock_insufficientStock() {
+            ProductSku sku = ProductSku.builder().id(1L).stockTotal(2).stockReserved(0).build();
+
+            CoreException ex = assertThrows(CoreException.class, () -> productSkuService.reserveStock(sku, 3));
+            assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserDetailIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserDetailIntegrationTest.java
@@ -55,7 +55,7 @@ class UserDetailIntegrationTest {
             // arrange
             UserCommand.SignUp command = new UserCommand.SignUp(
                     "loginId123",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "loginId123@user.com"
@@ -71,7 +71,7 @@ class UserDetailIntegrationTest {
             assertThat(info.loginId()).isEqualTo("loginId123");
             assertThat(info.name()).isEqualTo("사용자1");
 
-            verify(userRepository).save(any(UserEntity.class));
+            verify(userRepository).save(any(User.class));
         }
 
         @DisplayName("[회원가입 실패]이미 존재하는 로그인 ID 로 회원가입을 시도하면 BAD_REQUEST 가 발생하고 저장은 실행되지 않는다.")
@@ -79,9 +79,9 @@ class UserDetailIntegrationTest {
         void failure_signUp_whenLoginIdExists() {
 
             //arrange
-            UserEntity saved = new UserEntity(
+            User saved = new User(
                     "loginId123",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "loginId123@user.com"
@@ -89,7 +89,7 @@ class UserDetailIntegrationTest {
             userRepository.save(saved);
 
             UserCommand.SignUp command = new UserCommand.SignUp(
-                    "loginId123", UserEntity.Gender.M,"사용자2","2025-07-07","loginId123@user.com"
+                    "loginId123", User.Gender.M,"사용자2","2025-07-07","loginId123@user.com"
             );
 
             // act
@@ -111,9 +111,9 @@ class UserDetailIntegrationTest {
         void success_myProfile_whenUserExists() {
 
             // arrange
-            UserEntity saved = new UserEntity(
+            User saved = new User(
                     "loginId123",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "loginId123@user.com"

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserUnitTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserUnitTest.java
@@ -29,9 +29,9 @@ class UserUnitTest {
         void failure_createUser_whenLoginIdIsInvalid(String userId) {
 
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new UserEntity(
+                new User(
                         userId,
-                        UserEntity.Gender.M,
+                        User.Gender.M,
                         "사용자1",
                         "2025-07-07",
                         "xx@yy.zz"
@@ -57,9 +57,9 @@ class UserUnitTest {
         void failure_createUser_whenEmailIsInvalid(String email) {
 
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new UserEntity(
+                new User(
                         "loginId1",
-                        UserEntity.Gender.M,
+                        User.Gender.M,
                         "사용자1",
                         "2025-07-07",
                         email
@@ -83,9 +83,9 @@ class UserUnitTest {
         void failure_createUser_whenBirthDateIsInvalid(String birth) {
 
             CoreException exception = assertThrows(CoreException.class, () -> {
-                new UserEntity(
+                new User(
                         "loginId1",
-                        UserEntity.Gender.M,
+                        User.Gender.M,
                         "사용자1",
                         birth,
                         "xx@yy.zz"
@@ -103,7 +103,7 @@ class UserUnitTest {
         void failure_createUser_whenGenderIsNull() {
 
             CoreException exception =  assertThrows(CoreException.class, () -> {
-                new UserEntity(
+                new User(
                         "loginId1",
                         null,
                         "사용자1",

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,6 +1,6 @@
 package com.loopers.interfaces.api.point;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.controller.point.PointV1Request;
@@ -53,9 +53,9 @@ public class PointV1ApiE2ETest {
         void success_charge_whenUserExistsAndAmountIsValid() {
 
             String loginId = "user111";
-            UserEntity user = new UserEntity(
+            User user = new User(
                     loginId,
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "loginId123@user.com",
@@ -136,9 +136,9 @@ public class PointV1ApiE2ETest {
         void success_myPoint_whenUserExists() {
             // arrange
             String loginId = "user111";
-            UserEntity user = new UserEntity(
+            User user = new User(
                     loginId,
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "loginId123@user.com",

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,6 +1,6 @@
 package com.loopers.interfaces.api.user;
 
-import com.loopers.domain.user.UserEntity;
+import com.loopers.domain.user.User;
 import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.interfaces.api.controller.user.UserV1Request;
@@ -55,7 +55,7 @@ public class UserV1ApiE2ETest {
             //arrange
             UserV1Request.SignUp request = new UserV1Request.SignUp(
                     "user123",
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자123",
                     "2025-07-07",
                     "user123@email.com"
@@ -128,9 +128,9 @@ public class UserV1ApiE2ETest {
         void success_myProfile_whenUserExists() {
             // arrange
             String loginId = "user123";
-            UserEntity user = new UserEntity(
+            User user = new User(
                     loginId,
-                    UserEntity.Gender.M,
+                    User.Gender.M,
                     "사용자1",
                     "2025-07-07",
                     "loginId123@user.com"

--- a/modules/jpa/src/main/java/com/loopers/domain/BaseEntity.java
+++ b/modules/jpa/src/main/java/com/loopers/domain/BaseEntity.java
@@ -61,13 +61,4 @@ public abstract class BaseEntity {
             this.deletedAt = ZonedDateTime.now();
         }
     }
-
-    /**
-     * restore 연산은 멱등하게 동작할 수 있도록 한다. (삭제되지 않은 엔티티를 복원해도 동일한 결과가 나오도록)
-     */
-    public void restore() {
-        if (this.deletedAt != null) {
-            this.deletedAt = null;
-        }
-    }
 }


### PR DESCRIPTION
## 📌 Summary

- 브랜드 정보조회 기능 구현 및 테스트 작성
- 상품 목록 정보조회 기능 구현 및 테스트 작성
- 상품 상세정보조회 기능 구현 및 테스트 작성
- 좋아요 등록 기능 구현 및 테스트 작성
- 좋아요 취소 기능 구현 및 테스트 작성
- 내가 좋아요한 상품 목록조회 기능구현 및 테스트 작성
- 주문요청 기능 구현 및 테스트 작성
- 결제요청 기능구현 및 테스트 작성

## 💬 Review Points

1. **시퀀스 다이어그램 기반 도메인 모델링 진행 방식**
    - 이번 도메인 모델링은 기존 시퀀스 다이어그램을 기반으로 진행했습니다.
        - 하나의 시퀀스 다이어그램 = 하나의 유즈케이스로 대응
        - 시퀀스 다이어그램 내 Activate Bar(활성화 구간) 단위로 로직을 묶어 Service 단위로 구현
        - 각 Service는 해당 도메인의 책임을 응집하도록 설계
    - 예: `주문요청`
        - 사용자 조회 → 상품 옵션 재고 조회/선점 → 상품 상태 변경 → 주문 생성
        - 각 단계별 책임을 도메인 Service로 나누고 ApplicationService에서 orchestration
    - 이렇게 하다 보니 ApplicationService가 점점 커지고 있습니다.
        - 이 방식으로 진행해도 괜찮을까요?
        - 아니면 orchestration/조립 전용 Service를 하나 더 두는 게 좋을까요?
    -  관련소스코드 [[e37db14](https://github.com/Lexyyaa/Looper-Ecommerce/pull/4/commits/e37db147580f816ffd08c5b9c280ac3e48729c28)]

2. **목록 조회 방식 (정렬 + Projection)**
    - 처음에는 각 도메인별로 개별 조회 후 합치는 방식으로 구현하려 했으나,
      `like_cnt` 정렬을 위해 분기/메모리 정렬이 필요해져서 유지보수가 어려워졌습니다.
    - 그래서 DB 조인 + Projection을 사용해 한 번에 조회하는 방식으로 변경했습니다.
        - 조회 전용 DTO를 생성하여 반환
    - 현업에서도 조회 전용 API에서 이런 방식을 자주 쓰는지 궁금합니다.
    - 다만, 이 방식이 도메인 간 결합도를 높일 수 있는데 이 정도 결합도는 괜찮은지 판단이 어렵습니다.
    -  관련소스코드 [[844ab8f](https://github.com/Lexyyaa/Looper-Ecommerce/pull/4/commits/844ab8f8422939c7b1afee6c62ac8813eeb37a54)]

3. **상품 상세 조회(Product + Brand) 조합 방식**
    - 현재는 Product와 Brand를 각각 조회 후 ApplicationService에서 합쳐 반환하고 있습니다.
    - 체크리스트에는 "도메인 서비스에서 처리"라고 되어 있는데,
      제가 생각하기에 두 도메인은 독립적이라 이렇게 구현했습니다.
    - 혹시 별도의 조립 전용 Service(`Assembler`)를 만들어서 ApplicationService에서 호출하는 방식이 더 적합할까요?
    -  관련소스코드 [[63f535d](https://github.com/Lexyyaa/Looper-Ecommerce/pull/4/commits/63f535db26c617b0a8886da3e4452bcedd10b7bf)]

4. **Validator를 도메인 서비스처럼 사용**
    - 도메인 서비스의 역할을 나름 이해하기로는, 비즈니스 규칙 검증(Validation)도 도메인 서비스의 일부가 될 수 있다고 봤습니다.
    - 그래서 `Like` 도메인에 대해서도 별도의 `Validator` 클래스를 만들어
      중복 좋아요 방지 등 규칙을 검사하도록 구현했습니다.
    - 이런 식으로 Validator를 두는 접근이 맞는지 궁금합니다.
        - 아니면 이런 검증은 도메인 엔티티 메서드 내부에서 처리하는 게 더 바람직할까요?
    -  관련소스코드 [[c24bf02](https://github.com/Lexyyaa/Looper-Ecommerce/pull/4/commits/c24bf02281f3223863b74831b6db66c3e8482f87)]

## ✅ Checklist

- [x]  상품 정보 객체는 브랜드 정보, 좋아요 수를 포함한다.
- [x]  상품의 정렬 조건(`latest`, `price_asc`, `likes_desc`) 을 고려한 조회 기능을 설계했다
- [x]  상품은 재고를 가지고 있고, 주문 시 차감할 수 있어야 한다
- [x]  재고는 감소만 가능하며 음수 방지는 도메인 레벨에서 처리된다

### 👍 Like 도메인

- [x]  좋아요는 유저와 상품 간의 관계로 별도 도메인으로 분리했다
- [x]  중복 좋아요 방지를 위한 멱등성 처리가 구현되었다
- [x]  상품의 좋아요 수는 상품 상세/목록 조회에서 함께 제공된다
- [x]  단위 테스트에서 좋아요 등록/취소/중복 방지 흐름을 검증했다

### 🛒 Order 도메인

- [x]  주문은 여러 상품을 포함할 수 있으며, 각 상품의 수량을 명시한다
- [x]  주문 시 상품의 재고 차감, 유저 포인트 차감 등을 수행한다
- [x]  재고 부족, 포인트 부족 등 예외 흐름을 고려해 설계되었다
- [x]  단위 테스트에서 정상 주문 / 예외 주문 흐름을 모두 검증했다

### 🧩 도메인 서비스

- [ ]  도메인 간 협력 로직은 Domain Service에 위치시켰다
- [ ]  상품 상세 조회 시 Product + Brand 정보 조합은 도메인 서비스에서 처리했다
- [x]  복합 유스케이스는 Application Layer에 존재하고, 도메인 로직은 위임되었다
- [x]  도메인 서비스는 상태 없이, 도메인 객체의 협력 중심으로 설계되었다

### **🧱 소프트웨어 아키텍처 & 설계**

- [x]  전체 프로젝트의 구성은 아래 아키텍처를 기반으로 구성되었다
    - Application → **Domain** ← Infrastructure
- [x]  Application Layer는 도메인 객체를 조합해 흐름을 orchestration 했다
- [x]  핵심 비즈니스 로직은 Entity, VO, Domain Service 에 위치한다
- [x]  Repository Interface는 Domain Layer 에 정의되고, 구현체는 Infra에 위치한다
- [x]  패키지는 계층 + 도메인 기준으로 구성되었다 (`/domain/order`, `/application/like` 등)
- [x]  테스트는 외부 의존성을 분리하고, Fake/Stub 등을 사용해 단위 테스트가 가능하게 구성되었다

### **🐣 테스트 **

- [x]  모든 테스트가 실패 없이 통과함
<img width="737" height="493" alt="image" src="https://github.com/user-attachments/assets/741c9919-8228-459e-9c95-c7ad1d6fbff9" />

