### PR TITLE
[Round 4] Lock 을 통한 동시성 제어 및 쿠폰 기능 개발

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -4,4 +4,5 @@ import java.util.Optional;
 
 public interface BrandRepository {
     Optional<Brand> findById(long id);
+    Brand save(Brand brand);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CartCouponProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CartCouponProcessor.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class CartCouponProcessor implements CouponProcessor {
+
+    @Override
+    public Coupon.TargetType getTargetType() {
+        return Coupon.TargetType.CART;
+    }
+
+    @Override
+    public void validate(UserCoupon userCoupon, BigDecimal originalPrice) {
+        if (originalPrice.compareTo(userCoupon.getCoupon().getMinOrderAmount()) < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "최소 주문 금액을 충족하지 못했습니다.");
+        }
+    }
+
+    @Override
+    public BigDecimal apply(BigDecimal originalPrice, Coupon coupon) {
+        return coupon.discount(originalPrice);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,17 +1,22 @@
 package com.loopers.domain.coupon;
 
-import com.loopers.domain.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
+import java.time.ZonedDateTime;
 
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "discount_type", discriminatorType = DiscriminatorType.STRING)
 @Table(name = "coupon")
 @Getter
-public abstract class Coupon extends BaseEntity {
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Coupon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,6 +51,15 @@ public abstract class Coupon extends BaseEntity {
     @Column(name = "min_order_amount")
     protected BigDecimal minOrderAmount;
 
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private ZonedDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private ZonedDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private ZonedDateTime deletedAt;
+
     public enum DiscountType {
         AMOUNT, RATE
     }
@@ -55,4 +69,17 @@ public abstract class Coupon extends BaseEntity {
     }
 
     public abstract BigDecimal discount(BigDecimal originalAmount);
+
+    @PrePersist
+    void onCreate() {
+        ZonedDateTime now = ZonedDateTime.now();
+        if (createdAt == null) createdAt = now;
+        if (updatedAt == null) updatedAt = now;
+        if (minOrderAmount == null) minOrderAmount = BigDecimal.ZERO;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = ZonedDateTime.now();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,0 +1,58 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "discount_type", discriminatorType = DiscriminatorType.STRING)
+@Table(name = "coupon")
+@Getter
+public abstract class Coupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "coupon_code", unique = true, nullable = false)
+    private String couponCode;
+
+    @Column(name = "coupon_name", nullable = false)
+    private String couponName;
+
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discount_type", insertable = false, updatable = false)
+    private DiscountType discountType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private TargetType targetType;
+
+    @Column(name = "discount_amount")
+    protected BigDecimal discountAmount;
+
+    @Column(name = "discount_rate")
+    protected BigDecimal discountRate;
+
+    @Column(name = "max_discount_amount")
+    protected BigDecimal maxDiscountAmount;
+
+    @Column(name = "min_order_amount")
+    protected BigDecimal minOrderAmount;
+
+    public enum DiscountType {
+        AMOUNT, RATE
+    }
+
+    public enum TargetType {
+        CART, PRODUCT, BRAND, CATEGORY
+    }
+
+    public abstract BigDecimal discount(BigDecimal originalAmount);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponProcessor.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.coupon;
+
+import java.math.BigDecimal;
+
+public interface CouponProcessor {
+
+    Coupon.TargetType getTargetType();
+
+    void validate(UserCoupon userCoupon, BigDecimal originalPrice);
+
+    BigDecimal apply(BigDecimal originalPrice, Coupon coupon);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponProcessorFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponProcessorFactory.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class CouponProcessorFactory {
+
+    private final Map<Coupon.TargetType, CouponProcessor> processorMap;
+
+    public CouponProcessorFactory(List<CouponProcessor> processors) {
+        this.processorMap = processors.stream()
+                .collect(Collectors.toMap(CouponProcessor::getTargetType, processor -> processor));
+    }
+
+    public CouponProcessor getProcessor(Coupon.TargetType targetType) {
+        CouponProcessor processor = processorMap.get(targetType);
+        if (processor == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "해당 쿠폰 타입을 지원하는 Processor가 없습니다.");
+        }
+        return processor;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Optional<UserCoupon> findByUserCouponId(Long userCouponId);
+    Coupon save(Coupon coupon);
+    CouponUsage save(CouponUsage couponUsage);
+    UserCoupon save(UserCoupon userCoupon);
+    Optional<UserCoupon> findByIdWithPessimisticLock(Long userCouponId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,54 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.user.User;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+    private final CouponProcessorFactory couponProcessorFactory;
+
+    @Transactional
+    public void applyCouponsToOrder(OrderCommand.CreateOrder command, User user, Order order) {
+        if (command.cartCouponId() == null) {
+            order.updateFinalPrice(order.getPrice());
+            return;
+        }
+
+        // UserCoupon 조회
+        UserCoupon userCoupon = couponRepository.findByIdWithPessimisticLock(command.cartCouponId())
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다."));
+
+        // 쿠폰 타입에 맞는 Processor 가져옴
+        Coupon.TargetType targetType = userCoupon.getCoupon().getTargetType();
+        CouponProcessor processor = couponProcessorFactory.getProcessor(targetType);
+
+        // 유효성 검증
+        userCoupon.checkAvailability(user.getId());
+        BigDecimal originalPrice = BigDecimal.valueOf(order.getPrice());
+        processor.validate(userCoupon, originalPrice);
+
+        //쿠폰적용 및 최종결제예정금액 계산
+        BigDecimal finalPrice = processor.apply(originalPrice, userCoupon.getCoupon());
+        BigDecimal discountedAmount = originalPrice.subtract(finalPrice);
+
+        // 쿠폰 사용 처리
+        userCoupon.use();
+        couponRepository.save(userCoupon);
+        CouponUsage usage = CouponUsage.create(userCoupon, discountedAmount);
+
+        // 주문정보 변경
+        order.updateFinalPrice(finalPrice.longValue());
+        order.addCouponUsage(usage);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponUsage.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponUsage.java
@@ -38,12 +38,11 @@ public class CouponUsage  extends BaseEntity {
     @Column(name = "used_at", nullable = false)
     private LocalDateTime usedAt;
 
-    public static CouponUsage create(UserCoupon userCoupon, Order order, BigDecimal discountedAmount) {
+    public static CouponUsage create(UserCoupon userCoupon, BigDecimal discountedAmount) {
         Coupon coupon = userCoupon.getCoupon();
 
         return CouponUsage.builder()
                 .userCoupon(userCoupon)
-                .order(order)
                 .discountedAmount(discountedAmount)
                 .targetType(coupon.getTargetType())
                 .usedAt(LocalDateTime.now())

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponUsage.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponUsage.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.order.Order;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "coupon_usage")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class CouponUsage  extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false, updatable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_coupon_id", nullable = false)
+    private UserCoupon userCoupon;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private Coupon.TargetType targetType;
+
+    @Column(name = "discounted_amount", nullable = false)
+    private BigDecimal discountedAmount;
+
+    @Column(name = "used_at", nullable = false)
+    private LocalDateTime usedAt;
+
+    public static CouponUsage create(UserCoupon userCoupon, Order order, BigDecimal discountedAmount) {
+        Coupon coupon = userCoupon.getCoupon();
+
+        return CouponUsage.builder()
+                .userCoupon(userCoupon)
+                .order(order)
+                .discountedAmount(discountedAmount)
+                .targetType(coupon.getTargetType())
+                .usedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedAmountCoupon.java
@@ -1,0 +1,48 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+@Entity
+@DiscriminatorValue("AMOUNT")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FixedAmountCoupon extends Coupon {
+
+    public static FixedAmountCoupon create(
+            String couponCode,
+            String couponName,
+            int quantity,
+            TargetType targetType,
+            BigDecimal minOrderAmount,
+            BigDecimal discountAmount) {
+
+        return FixedAmountCoupon.builder()
+                .couponCode(couponCode)
+                .couponName(couponName)
+                .quantity(quantity)
+                .targetType(targetType)
+                .minOrderAmount(minOrderAmount)
+                .discountAmount(discountAmount)
+                .createdAt(ZonedDateTime.now())
+                .build();
+    }
+
+    @Override
+    public BigDecimal discount(BigDecimal originalAmount) {
+        BigDecimal discountedPrice = originalAmount.subtract(this.getDiscountAmount());
+        return discountedPrice.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : discountedPrice.setScale(0, RoundingMode.DOWN);
+    }
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedRateCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/FixedRateCoupon.java
@@ -1,0 +1,55 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.ZonedDateTime;
+
+@Slf4j
+@Entity
+@DiscriminatorValue("RATE")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FixedRateCoupon extends Coupon {
+
+    public static FixedRateCoupon create(
+            String couponCode,
+            String couponName,
+            int quantity,
+            TargetType targetType,
+            BigDecimal minOrderAmount,
+            BigDecimal discountRate,
+            BigDecimal maxDiscountAmount) {
+
+        return FixedRateCoupon.builder()
+                .couponCode(couponCode)
+                .couponName(couponName)
+                .quantity(quantity)
+                .targetType(targetType)
+                .minOrderAmount(minOrderAmount)
+                .discountRate(discountRate)
+                .maxDiscountAmount(maxDiscountAmount)
+                .createdAt(ZonedDateTime.now())
+                .build();
+    }
+
+    @Override
+    public BigDecimal discount(BigDecimal originalAmount) {
+
+        BigDecimal discountAmount = originalAmount.multiply(this.getDiscountRate().divide(new BigDecimal("100"), 2, RoundingMode.HALF_UP));
+        if (this.getMaxDiscountAmount() != null && discountAmount.compareTo(this.getMaxDiscountAmount()) > 0) {
+            discountAmount = this.getMaxDiscountAmount();
+        }
+
+        BigDecimal finalPrice = originalAmount.subtract(discountAmount);
+        return finalPrice.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : finalPrice.setScale(0, RoundingMode.DOWN);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -1,0 +1,61 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_coupon")
+@Getter
+public class UserCoupon extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private CouponStatus status;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
+    public enum CouponStatus {
+        ISSUED, USED, CANCELED
+    }
+
+    public void checkAvailability(Long currentUserId) {
+        if (!this.userId.equals(currentUserId)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "본인의 쿠폰만 사용할 수 있습니다.");
+        }
+
+        if (this.status != CouponStatus.ISSUED) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용할 수 없는 상태의 쿠폰입니다.");
+        }
+
+        if (LocalDateTime.now().isAfter(this.expiredAt)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "만료된 쿠폰입니다.");
+        }
+    }
+    public void use() {
+        this.status = CouponStatus.USED;
+        this.usedAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -4,12 +4,15 @@ import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_coupon")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Getter
 public class UserCoupon extends BaseEntity {
 
@@ -39,6 +42,20 @@ public class UserCoupon extends BaseEntity {
 
     public enum CouponStatus {
         ISSUED, USED, CANCELED
+    }
+
+    public static UserCoupon create(Long userId,
+                                    Coupon coupon,
+                                    CouponStatus status,
+                                    LocalDateTime issuedAt,
+                                    LocalDateTime expiredAt) {
+        return UserCoupon.builder()
+                .userId(userId)
+                .coupon(coupon)
+                .status(status)
+                .issuedAt(issuedAt)
+                .expiredAt(expiredAt)
+                .build();
     }
 
     public void checkAvailability(Long currentUserId) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -1,6 +1,9 @@
 package com.loopers.domain.order;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.domain.coupon.CouponUsage;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,21 +18,24 @@ import java.util.List;
 @Table(name = "orders")
 public class Order extends BaseEntity {
 
-    public enum Status {
-        PENDING,
-        CONFIRMED,
-        CANCELED
-    }
-
     @Column(name = "user_id", nullable = false, updatable = false)
     private Long userId;
 
     @Column(name = "price", nullable = false)
     private Long price;
 
+    @Column(name = "final_price", nullable = false)
+    private Long finalPrice;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;
+
+    public enum Status {
+        PENDING,
+        CONFIRMED,
+        CANCELED
+    }
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -40,26 +46,53 @@ public class Order extends BaseEntity {
         item.setOrder(this);
     }
 
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<CouponUsage> couponUsages = new ArrayList<>();
+
+    public void addCouponUsage(CouponUsage usage) {
+        if (!this.couponUsages.contains(usage)) {
+            this.couponUsages.add(usage);
+        }
+        if (usage.getOrder() != this) {
+            usage.setOrder(this);
+        }
+    }
+
     public void addPrice(Long amount) {
+        if(amount < 1){
+            throw new CoreException(ErrorType.BAD_REQUEST, "금액은 1원 이상이어야 합니다.");
+        }
         this.price += amount;
+    }
+
+    public void updatePrice(Long amount) {
+        if(amount < 1){
+            throw new CoreException(ErrorType.BAD_REQUEST, "금액은 1원 이상이어야 합니다.");
+        }
+        this.price = amount;
+    }
+
+    public void updateFinalPrice(Long newFinalPrice) {
+        this.finalPrice = newFinalPrice;
     }
 
     public void cancel() {
         if (this.status == Status.CANCELED) {
-            throw new IllegalStateException("이미 취소된 주문입니다.");
+            throw new CoreException(ErrorType.BAD_REQUEST,"이미 취소된 주문입니다.");
         }
         this.status = Status.CANCELED;
     }
 
     public void isConfirmed() {
         if (this.status == Status.CONFIRMED) {
-            throw new IllegalStateException("이미 결제된 주문입니다.");
+            throw new CoreException(ErrorType.BAD_REQUEST,"이미 결제된 주문입니다.");
         }
     }
 
     public void confirm() {
         if (this.status != Status.PENDING) {
-            throw new IllegalStateException("결제 전 상태에서만 확정할 수 있습니다.");
+            throw new CoreException(ErrorType.BAD_REQUEST,"결제 전 상태에서만 확정할 수 있습니다.");
         }
         this.status = Status.CONFIRMED;
     }
@@ -68,6 +101,7 @@ public class Order extends BaseEntity {
         return Order.builder()
                 .userId(userId)
                 .price(price)
+                .finalPrice(price)
                 .status(Status.PENDING)
                 .build();
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderCommand.java
@@ -6,14 +6,14 @@ public class OrderCommand {
 
     public record CreateOrder(
             String loginId,
-            List<OrderItemCommand> items
-    ) {
-
-    }
+            List<OrderItemCommand> items,
+            Long cartCouponId
+    ) {}
 
     public record OrderItemCommand(
             Long productSkuId,
-            int quantity
+            int quantity,
+            Long itemCouponId
     ) {}
 
     public record CancelOrder(
@@ -26,3 +26,7 @@ public class OrderCommand {
             Long orderId
     ) {}
 }
+
+
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderInfo.java
@@ -9,6 +9,7 @@ public class OrderInfo {
             Long orderId,
             Long userId,
             Long price,
+            Long finalPrice,
             Order.Status status,
             ZonedDateTime createdAt,
             List<OrderItemInfo> items
@@ -18,6 +19,7 @@ public class OrderInfo {
                     order.getId(),
                     order.getUserId(),
                     order.getPrice(),
+                    order.getFinalPrice(),
                     order.getStatus(),
                     order.getCreatedAt(),
                     order.getOrderItems().stream()

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -19,7 +19,7 @@ public class Payment extends BaseEntity {
     }
 
     public enum Status {
-        PAID, CANCELLED
+        PENDING, PAID, CANCELLED
     }
 
     @Column(name = "user_id", nullable = false, updatable = false)
@@ -39,9 +39,22 @@ public class Payment extends BaseEntity {
     @Column(nullable = false)
     private Status status;
 
-    public void cancel() {
+    public void pay(Long userId) {
+        if (this.status == Status.PAID) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 결제 완료 상태입니다.");
+        }
         if (this.status == Status.CANCELLED) {
-            throw new CoreException(ErrorType.BAD_REQUEST, "이미 취소된 결제입니다.");
+            throw new CoreException(ErrorType.BAD_REQUEST, "취소된 건은 결제할 수 없습니다.");
+        }
+        this.status = Status.PAID;
+    }
+
+    public void cancel(Long userId) {
+        if (this.getStatus() == Payment.Status.CANCELLED) {
+            throw new CoreException(ErrorType.BAD_REQUEST,"이미 취소된 결제입니다.");
+        }
+        if (this.status != Status.PAID) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "결제 완료 건만 취소할 수 있습니다.");
         }
         this.status = Status.CANCELLED;
     }
@@ -52,7 +65,7 @@ public class Payment extends BaseEntity {
                 .orderId(orderId)
                 .amount(amount)
                 .method(method)
-                .status(Status.PAID)
+                .status(Status.PENDING)
                 .build();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
@@ -5,7 +5,7 @@ public class PaymentCommand {
             String loginId,
             Long orderId,
             Long amount,
-            String method // "POINT" or "CREDIT"
+            String method
     ) {}
 
     public record CancelPayment(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -1,6 +1,5 @@
 package com.loopers.domain.payment;
 
-import com.loopers.domain.user.User;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +12,7 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
 
     public Payment save(Payment payment) {
+        payment.pay(payment.getUserId());
         return paymentRepository.save(payment);
     }
 
@@ -21,17 +21,8 @@ public class PaymentService {
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 결제입니다."));
     }
 
-    public void validateCancelable(Payment payment, User user) {
-        if (!payment.getUserId().equals(user.getId())) {
-            throw new CoreException(ErrorType.BAD_REQUEST,"본인의 결제만 취소할 수 있습니다.");
-        }
-        if (payment.getStatus() == Payment.Status.CANCELLED) {
-            throw new CoreException(ErrorType.BAD_REQUEST,"이미 취소된 결제입니다.");
-        }
-    }
-
     public Payment cancelPayment(Payment currPayment) {
-        currPayment.cancel();
+        currPayment.cancel(currPayment.getUserId());
         Payment payment = paymentRepository.save(currPayment);
         return payment;
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -16,6 +16,9 @@ public interface ProductRepository {
     Product saveProduct(Product product);
 
     ProductSku saveProductSku(ProductSku productSku);
+    ProductSku saveProductSkuAndFlush(ProductSku productSku);
 
     boolean existsAvailableStock(Long productId);
+
+    Optional<ProductSku> findByIdWithOptimisticLock(Long skuId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductSku.java
@@ -18,6 +18,9 @@ public class ProductSku extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
@@ -48,6 +51,7 @@ public class ProductSku extends BaseEntity {
         return ProductSku.builder()
                 .product(product)
                 .sku(sku)
+                .status(Status.ACTIVE)
                 .price(price)
                 .stockTotal(stockTotal)
                 .stockReserved(stockReserved)
@@ -58,12 +62,19 @@ public class ProductSku extends BaseEntity {
         return (stockTotal - stockReserved) <= 0;
     }
 
-    public int avaliableQunatity() {
+    public void changeStatus(ProductSku.Status status) {
+        this.status = status;
+    }
+
+    public int availableQuantity() {
         return (stockTotal - stockReserved);
     }
 
     public void reserveStock(int quantity) {
-        if (avaliableQunatity() < quantity) {
+        if (quantity < 1) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "선점 수량은 1 이상이어야 합니다.");
+        }
+        if (availableQuantity() < quantity) {
             throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다.");
         }
         stockReserved += quantity;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/User.java
@@ -81,6 +81,17 @@ public class User extends BaseEntity {
         this.point = point;
     }
 
+    public static User create(String loginId, Gender gender, String name, String birth, String email, Long point) {
+        return User.builder()
+                .loginId(loginId)
+                .gender(gender)
+                .name(name)
+                .birth(birth)
+                .email(email)
+                .point(point)
+                .build();
+    }
+
     public static void validateUniqueLoginId(boolean exists) {
         if(exists){
             throw new CoreException(ErrorType.BAD_REQUEST,"이미 존재하는 ID 입니다.");
@@ -92,5 +103,15 @@ public class User extends BaseEntity {
             throw new CoreException(ErrorType.BAD_REQUEST,"충전 금액은 0 보다 커야 합니다.");
         }
         this.point += amount;
+    }
+
+    public void use(Long amount){
+        if(amount <= 0){
+            throw new CoreException(ErrorType.BAD_REQUEST,"결제 금액은 0 보다 커야 합니다.");
+        }
+        if(amount > point){
+            throw new CoreException(ErrorType.BAD_REQUEST,"보유 포인트가 부족합니다.");
+        }
+        this.point -= amount;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -6,5 +6,6 @@ public interface UserRepository {
     Optional<User> findByLoginId(String loginId);
     User save(User user);
     boolean existsByLoginId(String loginId);
+    Optional<User> findByLoginIdWithPessimisticLock(String loginId);
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -34,6 +34,14 @@ public class UserService {
     }
 
     @Transactional
+    public User getUserWithLock(String loginId) {
+        User user = userRepository.findByLoginIdWithPessimisticLock(loginId).orElseThrow(
+                () -> new CoreException(ErrorType.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
+        );
+        return user;
+    }
+
+    @Transactional
     public UserInfo.Point charge(UserCommand.Charge command){
         User currPoint = userRepository.findByLoginId(command.loginId()).orElseThrow(
                 () -> new CoreException(ErrorType.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
@@ -44,10 +52,16 @@ public class UserService {
         return UserInfo.Point.from(point);
     }
 
-
     public UserInfo.Point myPoint(String loginId){
         User user = userRepository.findByLoginId(loginId).orElse(null);
         return user == null ? null : UserInfo.Point.from(user);
+    }
+
+    public UserInfo.Point use(String loginId,Long amount){
+        User currPoint = userRepository.findByLoginIdWithPessimisticLock(loginId).orElse(null);
+        currPoint.use(amount);
+        User point = userRepository.save(currPoint);
+        return UserInfo.Point.from(point);
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/brand/BrandRepositoryImpl.java
@@ -17,4 +17,9 @@ public class BrandRepositoryImpl implements BrandRepository {
     public Optional<Brand> findById(long id) {
         return brandJpaRepository.findById(id);
     }
+
+    @Override
+    public Brand save(Brand brand) {
+        return brandJpaRepository.save(brand);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+    Optional<Coupon> findByCouponCode(String couponCode);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.CouponUsage;
+import com.loopers.domain.coupon.UserCoupon;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponJpaRepository couponJpaRepository;
+    private final UserCouponJpaRepository userCouponJpaRepository;
+    private final CouponUsageJpaRepository couponUsageJpaRepository;
+
+    @Override
+    public Optional<UserCoupon> findByUserCouponId(Long userCouponId) {
+        return userCouponJpaRepository.findById(userCouponId);
+    }
+
+    @Override
+    public Coupon save(Coupon coupon) {
+        return couponJpaRepository.save(coupon);
+    }
+
+    @Override
+    public CouponUsage save(CouponUsage couponUsage) {
+        return couponUsageJpaRepository.save(couponUsage);
+    }
+
+    @Override
+    public UserCoupon save(UserCoupon userCoupon) {
+        return userCouponJpaRepository.save(userCoupon);
+    }
+
+    @Override
+    public Optional<UserCoupon> findByIdWithPessimisticLock(Long userCouponId) {
+        return userCouponJpaRepository.findByIdWithPessimisticLock(userCouponId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponUsageJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponUsageJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponUsage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponUsageJpaRepository extends JpaRepository<CouponUsage, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.UserCoupon;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface UserCouponJpaRepository extends JpaRepository<UserCoupon, Long> {
+
+    Optional<UserCoupon> findById(Long Id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT uc FROM UserCoupon uc WHERE uc.id = :id")
+    Optional<UserCoupon> findByIdWithPessimisticLock(@Param("id") Long Id);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface UserCouponJpaRepository extends JpaRepository<UserCoupon, Long> {
-
     Optional<UserCoupon> findById(Long Id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -50,7 +50,19 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public ProductSku saveProductSkuAndFlush(ProductSku productSku) {
+        ProductSku savedProductSku = productSkuJpaRepository.save(productSku);
+        productSkuJpaRepository.flush();
+        return savedProductSku;
+    }
+
+    @Override
     public boolean existsAvailableStock(Long productId) {
         return productSkuJpaRepository.existsAvailableStock(productId);
+    }
+
+    @Override
+    public Optional<ProductSku> findByIdWithOptimisticLock(Long skuId) {
+        return productSkuJpaRepository.findByIdWithOptimisticLock(skuId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductSkuJpaRepository.java
@@ -1,23 +1,30 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.ProductSku;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductSkuJpaRepository extends JpaRepository<ProductSku, Long> {
 
     @Query("SELECT s FROM ProductSku s WHERE s.product.id = :productId")
     List<ProductSku> findAllByProductId(@Param("productId") Long productId);
 
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    @Query("SELECT ps FROM ProductSku ps WHERE ps.id = :id")
+    Optional<ProductSku> findByIdWithOptimisticLock(@Param("id") Long id);
+
     @Query("""
-    SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END
-    FROM ProductSku s
-    WHERE s.product.id = :productId
-      AND (s.stockTotal - s.stockReserved) > 0
-""")
+        SELECT CASE WHEN COUNT(s) > 0 THEN true ELSE false END
+        FROM ProductSku s
+        WHERE s.product.id = :productId
+          AND (s.stockTotal - s.stockReserved) > 0
+    """)
     boolean existsAvailableStock(@Param("productId") Long productId);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserJpaRepository.java
@@ -1,7 +1,9 @@
 package com.loopers.infrastructure.user;
 
 import com.loopers.domain.user.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,6 +13,10 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.loginId = :loginId")
     Optional<User> findbyLoginId(@Param("loginId") String loginId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM User u WHERE u.loginId = :loginId")
+    Optional<User> findByLoginIdWithPessimisticLock(@Param("loginId") String loginId);
 
     boolean existsByLoginId(String loginId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/user/UserRepositoryImpl.java
@@ -26,4 +26,9 @@ public class UserRepositoryImpl implements UserRepository {
     public boolean existsByLoginId(String loginId) {
         return jpaRepository.existsByLoginId(loginId);
     }
+
+    @Override
+    public Optional<User> findByLoginIdWithPessimisticLock(String loginId) {
+        return jpaRepository.findByLoginIdWithPessimisticLock(loginId);
+    }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeConcurrencyTest.java
@@ -1,0 +1,120 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.*;
+import com.loopers.domain.product.*;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DisplayName("LikeApplicationService 동시성 테스트")
+class LikeConcurrencyTest {
+
+    @Autowired
+    LikeApplicationService likeApplicationService;
+
+    @Autowired
+    LikeRepository likeRepository;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired UserRepository userRepository;
+
+    Long productId;
+
+    @BeforeEach
+    void setUp() {
+        Product product = Product.create("맥북프로", Product.Status.ACTIVE, 1L);
+        product = productRepository.saveProduct(product);
+        productId = product.getId();
+    }
+
+    private User createTestUser(String login, String email) {
+        User user = User.create(login, User.Gender.M, "사용자-" + login, "2020-01-01", email, 0L);
+        return userRepository.save(user);
+    }
+
+    @DisplayName("[동시성] 동일한 상품에 대해 여러명이 좋아요 요청해도, 좋아요 수가 정확히 증가한다")
+    @Test
+    void concurrency_like_cnt() throws InterruptedException {
+        int userCount = 100;
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < userCount; i++) {
+            users.add(createTestUser("user" + i, "massive" + i + "@test.com"));
+        }
+        CountDownLatch latch = new CountDownLatch(userCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(userCount)) {
+            for (int i = 0; i < userCount; i++) {
+                final String loginId = users.get(i).getLoginId();
+                executor.submit(() -> {
+                    try {
+                        LikeCommand.Like cmd = new LikeCommand.Like(loginId, productId, LikeTargetType.PRODUCT);
+                        likeApplicationService.like(cmd);
+                        successCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+        }
+
+        long finalLikeCount = likeRepository.countByTargetId(productId, LikeTargetType.PRODUCT);
+        assertThat(finalLikeCount).isEqualTo(userCount);
+        assertThat(successCount.get()).isEqualTo(userCount);
+    }
+
+    @DisplayName("[동시성] 동일한 상품에 대해 여러명이 싫어요(취소) 요청해도, 최종 좋아요 수가 정확히 0이 된다")
+    @Test
+    void concurrency_unlike_cnt() throws InterruptedException {
+        int userCount = 100;
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < userCount; i++) {
+            User u = createTestUser("u" + i, "u" + i + "@t.com");
+            users.add(u);
+            try {
+                likeApplicationService.like(new LikeCommand.Like(u.getLoginId(), productId, LikeTargetType.PRODUCT));
+            } catch (Exception ignore) {}
+        }
+
+        CountDownLatch latch = new CountDownLatch(userCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(userCount)) {
+            for (User u : users) {
+                final String loginId = u.getLoginId();
+                executor.submit(() -> {
+                    try {
+                        LikeCommand.Like cmd = new LikeCommand.Like(loginId, productId, LikeTargetType.PRODUCT);
+                        likeApplicationService.unlike(cmd);
+                        successCount.incrementAndGet();
+                    } catch (Exception ignore) {
+
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+        }
+
+        long finalLikeCount = likeRepository.countByTargetId(productId, LikeTargetType.PRODUCT);
+        assertThat(finalLikeCount).isEqualTo(0L);
+        assertThat(successCount.get()).isBetween(0, userCount);
+    }
+}
+
+
+

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderApplicationServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderApplicationServiceIntegrationTest.java
@@ -1,0 +1,195 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.FixedAmountCoupon;
+import com.loopers.domain.coupon.UserCoupon;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.order.OrderInfo;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@DisplayName("OrderApplicationService 통합 테스트")
+class OrderApplicationServiceIntegrationTest {
+
+    @Autowired
+    OrderApplicationService orderApplicationService;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    ProductSkuService productSkuService;
+
+    @Autowired
+    OrderService orderService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    CouponRepository couponRepository;
+
+    @Autowired
+    DatabaseCleanUp databaseCleanUp;
+
+    User user;
+    String loginId;
+    Long userId;
+    Long productId;
+    Long skuId;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.create("user1", User.Gender.M, "사용자1", "2020-02-20", "xx@yy.zz", 1000L));
+        loginId = user.getLoginId();
+        userId = user.getId();
+
+        Product product = productRepository.saveProduct(Product.create("맥북프로", Product.Status.ACTIVE, 1L));
+        productId = product.getId();
+
+        ProductSku sku = productRepository.saveProductSkuAndFlush(
+                ProductSku.create(product, "macbookpro-gray-16", 2000, 10, 0)
+        );
+        skuId = sku.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("[성공] 쿠폰 없이 주문 생성")
+    @Transactional
+    void success_order_without_coupon() {
+        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(new OrderCommand.OrderItemCommand(skuId, 2, null)),
+                null
+        );
+
+        OrderInfo.CreateOrder result = orderApplicationService.order(cmd);
+
+        Order saved = orderService.getOrder(result.orderId());
+        assertThat(saved.getPrice()).isEqualTo(4_000L);
+        assertThat(saved.getFinalPrice()).isEqualTo(4_000L);
+        assertThat(saved.getOrderItems()).hasSize(1);
+        assertThat(saved.getOrderItems().get(0).getQuantity()).isEqualTo(2);
+
+        ProductSku after = productSkuService.getBySkuId(skuId);
+        assertThat(after.getStockReserved()).isEqualTo(2);
+        assertThat(after.getStockTotal()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("[성공] 장바구니 정액 2000원 할인 적용")
+    @Transactional
+    void success_order_with_cart_amount_coupon() {
+        FixedAmountCoupon coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-2000")
+                .couponName("장바구니 2천원")
+                .quantity(100)
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(2000))
+                .build();
+        coupon = (FixedAmountCoupon) couponRepository.save(coupon);
+
+        UserCoupon uc = UserCoupon.create(
+                userId, coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusWeeks(1)
+        );
+        uc = couponRepository.save(uc);
+
+        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(new OrderCommand.OrderItemCommand(skuId, 1, null)),
+                uc.getId()
+        );
+
+        OrderInfo.CreateOrder result = orderApplicationService.order(cmd);
+
+        Order saved = orderService.getOrder(result.orderId());
+        assertThat(saved.getPrice()).isEqualTo(2000L);
+        assertThat(saved.getFinalPrice()).isEqualTo(0L);
+
+        assertThat(saved.getCouponUsages()).hasSize(1);
+        assertThat(saved.getCouponUsages().get(0).getUserCoupon().getId()).isEqualTo(uc.getId());
+        assertThat(saved.getCouponUsages().get(0).getDiscountedAmount()).isEqualByComparingTo("2000");
+
+        ProductSku after = productSkuService.getBySkuId(skuId);
+        assertThat(after.getStockReserved()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("[실패] 재고 부족 시 BAD_REQUEST")
+    void failure_order_insufficient_stock() {
+        Product product = productRepository.findBy(productId).orElseThrow();
+        ProductSku low = productRepository.saveProductSkuAndFlush(
+                ProductSku.create(product, "macbookpro-low-1", 1000, 1, 0)
+        );
+        Long lowSkuId = low.getId();
+
+        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(new OrderCommand.OrderItemCommand(lowSkuId, 2, null)),
+                null
+        );
+
+        CoreException ex = assertThrows(CoreException.class,
+                () -> orderApplicationService.order(cmd));
+        assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+        ProductSku after = productSkuService.getBySkuId(lowSkuId);
+        assertThat(after.getStockReserved()).isEqualTo(0);
+        assertThat(after.getStockTotal()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 취소 → 상태 CANCELED , 선점 재고 원복 ")
+    void success_cancel_order() {
+        OrderCommand.CreateOrder create = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(new OrderCommand.OrderItemCommand(skuId, 1, null)),
+                null
+        );
+        OrderInfo.CreateOrder created = orderApplicationService.order(create);
+
+        OrderCommand.CancelOrder cancel = new OrderCommand.CancelOrder(loginId, created.orderId());
+        OrderInfo.CancelOrder result = orderApplicationService.cancelOrder(cancel);
+
+        Order canceled = orderService.getOrder(result.orderId());
+        assertThat(canceled.getStatus()).isEqualTo(Order.Status.CANCELED);
+
+        ProductSku after = productSkuService.getBySkuId(skuId);
+        assertThat(after.getStockReserved()).isEqualTo(0);
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderApplicationServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderApplicationServiceTest.java
@@ -51,7 +51,8 @@ class OrderApplicationServiceTest {
         void success_order() {
             OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
                     "loginId",
-                    List.of(new OrderCommand.OrderItemCommand(10L, 2))
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2,null))
+                    , 1L
             );
             User user = User.builder().id(1L).build();
             ProductSku sku = ProductSku.builder()
@@ -73,7 +74,11 @@ class OrderApplicationServiceTest {
         @Test
         @DisplayName("[실패] 존재하지 않는 사용자일 경우 NOT_FOUND 에러를 반환한다.")
         void failure_userNotFound() {
-            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder("loginId", List.of());
+            OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                    "loginId",
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2,null)),
+                    1L
+            );
             when(userService.getUser("loginId"))
                     .thenThrow(new CoreException(ErrorType.NOT_FOUND, "사용자 없음"));
 
@@ -88,7 +93,8 @@ class OrderApplicationServiceTest {
         void failure_skuNotFound() {
             OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
                     "loginId",
-                    List.of(new OrderCommand.OrderItemCommand(10L, 1))
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2,null)),
+                    1L
             );
             User user = User.builder().id(1L).build();
             when(userService.getUser("loginId")).thenReturn(user);
@@ -106,7 +112,8 @@ class OrderApplicationServiceTest {
         void failure_insufficientStock() {
             OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
                     "loginId",
-                    List.of(new OrderCommand.OrderItemCommand(10L, 5))
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2,null)),
+                    1L
             );
             User user = User.builder().id(1L).build();
             ProductSku sku = ProductSku.builder().id(10L).build();
@@ -126,7 +133,8 @@ class OrderApplicationServiceTest {
         void success_updateProductStatusToSoldOut() {
             OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
                     "loginId",
-                    List.of(new OrderCommand.OrderItemCommand(10L, 2))
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2,null)),
+                    1L
             );
 
             User user = User.builder().id(1L).build();
@@ -156,9 +164,9 @@ class OrderApplicationServiceTest {
         void success_doNotUpdateStatusWhenNotAllSoldOut() {
             OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
                     "loginId",
-                    List.of(new OrderCommand.OrderItemCommand(10L, 2))
+                    List.of(new OrderCommand.OrderItemCommand(10L, 2,null)),
+                    1L
             );
-
             User user = User.builder().id(1L).build();
 
             ProductSku sku = ProductSku.builder()

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderConcurrencyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderConcurrencyTest.java
@@ -1,0 +1,166 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.domain.coupon.FixedAmountCoupon;
+import com.loopers.domain.coupon.UserCoupon;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.order.OrderInfo;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DisplayName("주문 동시성 테스트")
+class OrderConcurrencyTest {
+
+    @Autowired
+    OrderApplicationService orderApplicationService;
+    @Autowired
+    ProductRepository productRepository;
+    @Autowired
+    ProductSkuService productSkuService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    CouponRepository couponRepository;
+    @Autowired
+    DatabaseCleanUp databaseCleanUp;
+
+    String loginId;
+    Long skuId;
+    Long userCouponId;
+
+    @BeforeEach
+    void setUp() {
+        User u  = userRepository.save(User.create("user1", User.Gender.M, "사용자1", "2020-02-20", "xx@yy.zz", 10000L));
+
+        loginId = u.getLoginId();
+
+        Product p = productRepository.saveProduct(Product.create("맥북프로", Product.Status.ACTIVE, 1L));
+        ProductSku sku = ProductSku.create(p, "macbookpro-gray-16", 2000, 100, 0);
+        skuId = productRepository.saveProductSkuAndFlush(sku).getId();
+
+        FixedAmountCoupon coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-500")
+                .couponName("장바구니 500원")
+                .quantity(1)
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(500))
+                .build();
+        coupon = (FixedAmountCoupon) couponRepository.save(coupon);
+
+        UserCoupon uc = UserCoupon.create(
+                u.getId(),
+                coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1)
+        );
+        userCouponId = couponRepository.save(uc).getId();
+    }
+
+    @AfterEach
+    void tearDown(){
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("[동시성] 재고가 충분해도 100명 중 1명만 성공하도록 낙관적 락 충돌 유도")
+    void stock_bounded_orders() throws InterruptedException {
+        int threads = 100;
+        CountDownLatch latch = new CountDownLatch(threads);
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger failed = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.submit(() -> {
+                    try {
+                        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                                loginId,
+                                List.of(new OrderCommand.OrderItemCommand(skuId, 1, null)),
+                                null
+                        );
+                        orderApplicationService.order(cmd);
+                        success.incrementAndGet();
+                    }  catch (Exception e) {
+                            failed.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(failed.get()).isEqualTo(threads - 1);
+    }
+
+    @Test
+    @DisplayName("[동시성] 1명의 사용자가 동일 쿠폰을 동시에 여러 번 사용하면 한 번만 성공한다")
+    void single_coupon_used_once() throws InterruptedException {
+        int threads = 100;
+        CountDownLatch latch = new CountDownLatch(threads);
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger failed = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            for (int i = 0; i < threads; i++) {
+                executor.submit(() -> {
+                    try {
+                        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                                loginId,
+                                List.of(new OrderCommand.OrderItemCommand(skuId, 1, null)),
+                                userCouponId
+                        );
+                        OrderInfo.CreateOrder res = orderApplicationService.order(cmd);
+                        assertThat(res.finalPrice()).isEqualTo(1500L);
+                        success.incrementAndGet();
+                    } catch (CoreException e) {
+                        failed.incrementAndGet();
+                    } catch (Exception e) {
+                        failed.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(failed.get()).isEqualTo(threads - 1);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentConcurrenyTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentConcurrenyTest.java
@@ -1,0 +1,155 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.order.OrderApplicationService;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DisplayName("결제 동시성 테스트")
+class PaymentConcurrenyTest {
+
+    @Autowired
+    PaymentApplicationService paymentApplicationService;
+
+    @Autowired
+    OrderApplicationService orderApplicationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    DatabaseCleanUp databaseCleanUp;
+
+    String loginId = "user1";
+    ProductSku sku;
+    long initialPoint = 10000L;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.save(User.create(loginId, User.Gender.M, "사용자1", "2020-02-20", "xx@yy.zz", initialPoint));
+
+        Product p = productRepository.saveProduct(Product.create("맥북프로", Product.Status.ACTIVE, 1L));
+        String uniqueSku = "macbookpro-gray-16-" + System.nanoTime();
+        sku = productRepository
+                .saveProductSkuAndFlush(ProductSku.create(p, uniqueSku, 200,200, 0));
+    }
+
+    @AfterEach
+    void tearDown(){
+        databaseCleanUp.truncateAllTables();
+    }
+
+
+    @DisplayName("[동시성] 동일 유저가 동시에 포인트 결제를 시도해도 잔액은 음수가 되지 않는다")
+    @Test
+    void concurrency_payment_point_can_not_be_negative() throws InterruptedException {
+        int threads = 40;
+        long payAmount = 200L;
+        CountDownLatch latch = new CountDownLatch(threads);
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger failed  = new AtomicInteger(0);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(threads)) {
+            for (int i = 0; i < threads; i++) {
+                executor.submit(() -> {
+                    try {
+                        OrderCommand.CreateOrder orderCmd = new OrderCommand.CreateOrder(
+                                loginId,
+                                List.of(new OrderCommand.OrderItemCommand(sku.getId(), 1,null)),
+                                null
+                        );
+                        var orderRes = orderApplicationService.order(orderCmd);
+
+                        PaymentCommand.CreatePayment payCmd = new PaymentCommand.CreatePayment(
+                                loginId,
+                                orderRes.orderId(),
+                                payAmount,
+                                "POINT"
+                        );
+                        paymentApplicationService.createPayment(payCmd);
+                        success.incrementAndGet();
+                    } catch (Exception e) {
+                        failed.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+        }
+
+        assertThat(success.get()).isBetween(0, 50);
+
+        User after = userRepository.findByLoginId(loginId).orElseThrow();
+        assertThat(after.getPoint()).isBetween(0L, initialPoint);
+    }
+
+    @Test
+    @DisplayName("[동시성] 동일 유저의 서로 다른 주문 동시 결제시 포인트 정확히 차감된다")
+    void concurrency_payment_use_correct_point() throws InterruptedException {
+        int threads = 40;
+        long payAmount = 200L;
+
+        CountDownLatch latch = new CountDownLatch(threads);
+        AtomicInteger success = new AtomicInteger(0);
+        AtomicInteger failed  = new AtomicInteger(0);
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(threads)) {
+            for (int i = 0; i < threads; i++) {
+                executor.submit(() -> {
+                    try {
+                        OrderCommand.CreateOrder orderCmd = new OrderCommand.CreateOrder(
+                                loginId,
+                                List.of(new OrderCommand.OrderItemCommand(sku.getId(), 1,null)),
+                                null
+                        );
+
+                        var orderRes = orderApplicationService.order(orderCmd);
+
+                        PaymentCommand.CreatePayment payCmd = new PaymentCommand.CreatePayment(
+                                loginId,
+                                orderRes.orderId(),
+                                payAmount,
+                                "POINT"
+                        );
+                        paymentApplicationService.createPayment(payCmd);
+                        success.incrementAndGet();
+                    } catch (Exception e) {
+                        failed.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            latch.await();
+        }
+
+        long expectedPoint = initialPoint - success.get() * payAmount;
+        User after = userRepository.findByLoginId(loginId).orElseThrow();
+        assertThat(after.getPoint()).isEqualTo(expectedPoint);
+        assertThat(failed.get()).isBetween(0, threads);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CartCouponProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CartCouponProcessorTest.java
@@ -1,0 +1,145 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("CartCouponProcessor")
+class CartCouponProcessorTest {
+
+    @Nested
+    @DisplayName("[정액 할인 - 장바구니 쿠폰]")
+    class AmountCouponTest{
+
+        @Test
+        @DisplayName("[성공] 최소주문금액 이상이면 검증 통과한다")
+        void success_validate_whenMeetsMinOrder() {
+            var processor = new CartCouponProcessor();
+
+            var coupon = FixedAmountCoupon.builder()
+                    .couponCode("CART-AMOUNT-1000")
+                    .couponName("장바구니 천원 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(10000))
+                    .discountAmount(BigDecimal.valueOf(1000))
+                    .build();
+
+            var userCoupon = UserCoupon.create(
+                    1L,
+                    coupon,
+                    UserCoupon.CouponStatus.ISSUED,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(1)
+            );
+
+            assertDoesNotThrow(() -> processor.validate(userCoupon, BigDecimal.valueOf(10000)));
+        }
+
+        @Test
+        @DisplayName("[실패] 최소주문금액 미달이면 CoreException 이 발생한다")
+        void failure_validate_whenBelowMinOrder() {
+            var processor = new CartCouponProcessor();
+
+            var coupon = FixedAmountCoupon.builder()
+                    .couponCode("CART-AMOUNT-1000")
+                    .couponName("장바구니 천원 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(10000))
+                    .discountAmount(BigDecimal.valueOf(1000))
+                    .build();
+
+            var userCoupon = UserCoupon.create(
+                    1L,
+                    coupon,
+                    UserCoupon.CouponStatus.ISSUED,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(1)
+            );
+
+            assertThatThrownBy(() -> processor.validate(userCoupon, BigDecimal.valueOf(9999)))
+                    .isInstanceOf(CoreException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("[정률 할인 - 장바구니 쿠폰]")
+    class RateCouponTest{
+        @Test
+        @DisplayName("[성공] 최소주문금액 이상이면 검증 통과한다")
+        void success_validate_whenMeetsMinOrder_withRateCoupon() {
+            var processor = new CartCouponProcessor();
+
+            var rateCoupon = FixedRateCoupon.builder()
+                    .couponCode("CART-RATE-10")
+                    .couponName("장바구니 10% 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(10000))
+                    .discountRate(BigDecimal.valueOf(10))
+                    .build();
+
+            var userCoupon = UserCoupon.create(
+                    1L,
+                    rateCoupon,
+                    UserCoupon.CouponStatus.ISSUED,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(1)
+            );
+
+            assertDoesNotThrow(() -> processor.validate(userCoupon, BigDecimal.valueOf(10000)));
+        }
+
+        @Test
+        @DisplayName("[실패] 최소주문금액 미달이면 예외가 발생한다")
+        void failure_validate_whenBelowMinOrder_withRateCoupon() {
+            var processor = new CartCouponProcessor();
+
+            var rateCoupon = FixedRateCoupon.builder()
+                    .couponCode("CART-RATE-10")
+                    .couponName("장바구니 10% 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(10000))
+                    .discountRate(BigDecimal.valueOf(10))
+                    .build();
+
+            var userCoupon = UserCoupon.create(
+                    1L,
+                    rateCoupon,
+                    UserCoupon.CouponStatus.ISSUED,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(1)
+            );
+
+            assertThatThrownBy(() -> processor.validate(userCoupon, BigDecimal.valueOf(9999)))
+                    .isInstanceOf(CoreException.class);
+        }
+
+         @Test
+         @DisplayName("[성공] 최대 할인 금액을 초과하면 최대 할인 금액만큼 할인된다 ")
+         void success_apply_respectsMaxDiscountCap_whenPresent() {
+             var processor = new CartCouponProcessor();
+
+             var rateCoupon = FixedRateCoupon.builder()
+                     .couponCode("CART-RATE-20")
+                     .couponName("장바구니 20% 할인 쿠폰")
+                     .targetType(Coupon.TargetType.CART)
+                     .minOrderAmount(BigDecimal.valueOf(10000))
+                     .discountRate(BigDecimal.valueOf(20))
+                     .maxDiscountAmount(BigDecimal.valueOf(2000))
+                     .build();
+
+             var original = BigDecimal.valueOf(15000);
+
+             var finalPrice = processor.apply(original, rateCoupon);
+
+             assertEquals(BigDecimal.valueOf(13000), finalPrice);
+         }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponEntityTest.java
@@ -1,0 +1,85 @@
+package com.loopers.domain.coupon;
+
+import org.junit.jupiter.api.DisplayName;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Coupon")
+public class CouponEntityTest {
+
+    @Nested
+    @DisplayName("[정액 할인 - 장바구니 쿠폰]")
+    class AmountCartCouponTest{
+
+        @Test
+        @DisplayName("[성공] 원금액에서 정액을 차감한다")
+        void success_discount() {
+            var coupon = FixedAmountCoupon.builder()
+                    .couponCode("CART-AMOUNT-1000")
+                    .couponName("장바구니 천원 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(5000))
+                    .discountAmount(BigDecimal.valueOf(1000))
+                    .build();
+
+            BigDecimal result = coupon.discount(BigDecimal.valueOf(5000));
+
+            assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(4000));
+        }
+
+        @Test
+        @DisplayName("[성공] 차감 후 0원 미만이면 0원처리한다")
+        void success_discount_clamped_to_zero() {
+            var coupon = FixedAmountCoupon.builder()
+                    .couponCode("CART-AMOUNT-10000")
+                    .couponName("장바구니 만원 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(1000))
+                    .discountAmount(BigDecimal.valueOf(10000))
+                    .build();
+
+            BigDecimal result = coupon.discount(BigDecimal.valueOf(5000));
+
+            assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(0));
+        }
+    }
+
+    @Nested
+    @DisplayName("[정률 할인 쿠폰]")
+    class RateCouponTest{
+        @Test
+        @DisplayName("[성공] 정률(10%)로 가격을 계산한다")
+        void success_discount_10percent() {
+            var coupon = FixedRateCoupon.builder()
+                    .couponCode("CART-RATE-10")
+                    .couponName("장바구니 10% 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(0))
+                    .discountRate(BigDecimal.valueOf(10))
+                    .maxDiscountAmount(BigDecimal.valueOf(10000))
+                    .build();
+
+            BigDecimal result = coupon.discount(BigDecimal.valueOf(12345));
+            assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(11110));
+        }
+
+        @Test
+        @DisplayName("[성공] 결과 금액은 0원 미만으로 내려가지 않는다")
+        void success_discount_not_negative() {
+            var coupon = FixedRateCoupon.builder()
+                    .couponCode("CART-RATE-10")
+                    .couponName("장바구니 90% 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(0))
+                    .discountRate(BigDecimal.valueOf(100))
+                    .build();
+
+            BigDecimal result = coupon.discount(BigDecimal.valueOf(999));
+            assertThat(result).isEqualByComparingTo(BigDecimal.valueOf(0));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponProcessorFactoryTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponProcessorFactoryTest.java
@@ -1,0 +1,44 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CouponProcessorFactory 단위 테스트")
+class CouponProcessorFactoryTest {
+
+    @Test
+    @DisplayName("[성공] CART 타입에 대해 CartCouponProcessor 를 반환한다")
+    void success_getProcessor_whenCart() {
+        var cartProcessor = new CartCouponProcessor();
+        var factory = new CouponProcessorFactory(List.of(cartProcessor));
+
+        var rateCoupon = FixedRateCoupon.builder()
+                .couponCode("CART-RATE-10")
+                .couponName("장바구니 10% 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountRate(BigDecimal.valueOf(10))
+                .build();
+
+        var processor = factory.getProcessor(rateCoupon.getTargetType());
+
+        assertThat(processor).isSameAs(cartProcessor);
+    }
+
+    @Test
+    @DisplayName("[실패] 등록되지 않은 타입이 예외가 발생한다")
+    void failure_getProcessor_whenUnsupportedType() {
+        var factory = new CouponProcessorFactory(List.of(new CartCouponProcessor()));
+
+        assertThatThrownBy(() -> factory.getProcessor(Coupon.TargetType.PRODUCT))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("해당 쿠폰 타입을 지원하는 Processor가 없습니다.");
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceIntegrationTest.java
@@ -1,0 +1,199 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@DisplayName("CouponService 통합 테스트 ")
+class CouponServiceIntegrationTest {
+
+    @Autowired
+    CouponService couponService;
+    @Autowired
+    CouponRepository couponRepository;
+    @Autowired
+    OrderService orderService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    ProductRepository productRepository;
+    @Autowired
+    DatabaseCleanUp databaseCleanUp;
+
+    User user;
+    String loginId;
+    Long userId;
+    Long skuId;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.create("user1", User.Gender.M, "사용자1","2020-02-20","xx@yy.zz",1000L);
+        user = userRepository.save(user);
+        userId = user.getId();
+        loginId = user.getLoginId();
+
+        Product product = Product.create("맥북프로", Product.Status.ACTIVE,1L);
+        product = productRepository.saveProduct(product);
+
+        ProductSku sku =  ProductSku.create(product, "macbookpro-gray-16",2000, 10, 0);
+        sku = productRepository.saveProductSkuAndFlush(sku);
+        skuId = sku.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("[성공] 쿠폰 없이 주문을 생성하면 최종 결제 금액이 원가와 동일하다")
+    void success_apply_no_coupon() {
+        Order order = Order.create(userId, 0L);
+        order.addOrderItem(OrderItem.create(skuId, 1));
+        order.updatePrice(10000L);
+        order = orderService.saveOrder(order);
+
+        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(
+                        new OrderCommand.OrderItemCommand(skuId, 1, null)
+                ),
+                null
+        );
+
+        couponService.applyCouponsToOrder(cmd, user, order);
+
+        assertThat(order.getFinalPrice()).isEqualTo(10000L);
+        assertThat(order.getCouponUsages()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 장바구니 정액 2,000원 할인 쿠폰을 적용하면 최종 결제 금액이 18000원이 되고 사용 내역이 기록된다")
+    void success_apply_cart_amount_coupon() {
+
+        User user1 = User.create("user1", User.Gender.M, "사용자1","2020-02-20","xx@yy.zz",1000L);
+        User currUser = userRepository.save(user1);
+
+        Order order = Order.create(currUser.getId(), 0L);
+        order.addOrderItem(OrderItem.create(skuId, 1));
+        order.updatePrice(20000L);
+        order = orderService.saveOrder(order);
+
+        FixedAmountCoupon coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-2000")
+                .couponName("장바구니 2천원 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(2000))
+                .build();
+
+        coupon = (FixedAmountCoupon) couponRepository.save(coupon);
+
+        UserCoupon uc = UserCoupon.create(currUser.getId(),
+                coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusWeeks(1));
+
+        uc = couponRepository.save(uc);
+
+        OrderCommand.CreateOrder command = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(new OrderCommand.OrderItemCommand(skuId, 1, null)),
+                uc.getId()
+        );
+
+        couponService.applyCouponsToOrder(command, currUser, order);
+
+        assertThat(order.getFinalPrice()).isEqualTo(18000L);
+        assertThat(order.getCouponUsages()).hasSize(1);
+        assertThat(order.getCouponUsages().get(0).getDiscountedAmount()).isEqualByComparingTo("2000");
+        assertThat(order.getCouponUsages().get(0).getUserCoupon().getId()).isEqualTo(uc.getId());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 쿠폰 ID로 쿠폰을 적용하면 NOT_FOUND 예외가 발생한다")
+    void failure_coupon_not_found() {
+        Order order = Order.create(userId, 0L);
+        order.addOrderItem(OrderItem.create(skuId, 1));
+        order.updatePrice(10000L);
+        Order currOrder = orderService.saveOrder(order);
+
+        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(new OrderCommand.OrderItemCommand(skuId, 1, null)),
+                999L
+        );
+
+        CoreException ex = assertThrows(CoreException.class,
+                () -> couponService.applyCouponsToOrder(cmd, user, currOrder));
+        assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[실패] 최소 주문 금액에 미달하는 경우 BAD_REQUEST 예외가 발생한다")
+    void failure_min_order_amount() {
+
+        User user1 = User.create("user1", User.Gender.M, "사용자1","2020-02-20","xx@yy.zz",1000L);
+        User currUser = userRepository.save(user1);
+
+
+        Order order = Order.create(userId, 0L);
+        order.addOrderItem(OrderItem.create(skuId, 1));
+        order.updatePrice(3000L);
+
+        Order currOrder = orderService.saveOrder(order);
+
+        FixedAmountCoupon coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-2000-MIN5000")
+                .couponName("장바구니 2천원 할인 쿠폰(최소5천)")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .quantity(100)
+                .build();
+        coupon = (FixedAmountCoupon) couponRepository.save(coupon);
+
+        UserCoupon uc = UserCoupon.create(
+                userId,
+                coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusWeeks(1)
+        );
+        uc = couponRepository.save(uc);
+
+        OrderCommand.CreateOrder cmd = new OrderCommand.CreateOrder(
+                loginId,
+                List.of(new OrderCommand.OrderItemCommand(skuId, 1, null)),
+                uc.getId()
+        );
+
+        CoreException ex = assertThrows(CoreException.class,
+                () -> couponService.applyCouponsToOrder(cmd, currUser, currOrder));
+        assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(uc.getStatus()).isEqualTo(UserCoupon.CouponStatus.ISSUED);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
@@ -1,0 +1,230 @@
+package com.loopers.domain.coupon;
+
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderCommand;
+import com.loopers.domain.user.User;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CouponService")
+class CouponServiceTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private CouponProcessorFactory couponProcessorFactory;
+
+    @InjectMocks
+    private CouponService couponService;
+
+    @Nested
+    @DisplayName("[쿠폰적용]")
+    class ApplyCouponsToOrder {
+
+        @Test
+        @DisplayName("[성공] 적용된쿠폰이 없다면 주문총액을 최종결제금액으로 설정한다")
+        void success_applyCouponsToOrder_whenCartCouponIdIsNull() {
+            // arrange
+            OrderCommand.CreateOrder command = mock(OrderCommand.CreateOrder.class);
+            when(command.cartCouponId()).thenReturn(null);
+
+            User user = mock(User.class);
+            Order order = mock(Order.class);
+            when(order.getPrice()).thenReturn(50000L);
+
+            // act
+            couponService.applyCouponsToOrder(command, user, order);
+
+            // assert
+            verify(order).updateFinalPrice(50000L);
+            verifyNoInteractions(couponRepository, couponProcessorFactory);
+        }
+
+        @Test
+        @DisplayName("[실패] cartCouponId로 UserCoupon을 찾지 못하면 NOT_FOUND 예외가 발생한다")
+        void failure_applyCouponsToOrder_whenUserCouponNotFound() {
+            // arrange
+            OrderCommand.CreateOrder command = mock(OrderCommand.CreateOrder.class);
+            when(command.cartCouponId()).thenReturn(1L);
+
+            when(couponRepository.findByUserCouponId(1L)).thenReturn(Optional.empty());
+
+            User user = mock(User.class);
+            Order order = mock(Order.class);
+
+            // act & assert
+            assertThatThrownBy(() -> couponService.applyCouponsToOrder(command, user, order))
+                    .isInstanceOf(CoreException.class)
+                    .extracting(ex -> ((CoreException) ex).getErrorType())
+                    .isEqualTo(ErrorType.NOT_FOUND);
+
+            verify(couponRepository, never()).save(any(CouponUsage.class));
+            verify(order, never()).updateFinalPrice(anyLong());
+        }
+
+        @Test
+        @DisplayName("[실패] 본인의 쿠폰이 아니면 checkAvailability에서 예외가 발생한다")
+        void failure_applyCouponsToOrder_whenUserIdMismatch() {
+            // arrange
+            OrderCommand.CreateOrder command = mock(OrderCommand.CreateOrder.class);
+            when(command.cartCouponId()).thenReturn(1L);
+
+            FixedAmountCoupon coupon = FixedAmountCoupon.builder()
+                    .couponCode("CART-AMOUNT-1000")
+                    .couponName("장바구니 천원 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.ZERO)
+                    .discountAmount(BigDecimal.valueOf(1000))
+                    .build();
+
+            UserCoupon userCoupon = UserCoupon.create(
+                    2L,
+                    coupon,
+                    UserCoupon.CouponStatus.ISSUED,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(1)
+            );
+            when(couponRepository.findByUserCouponId(1L)).thenReturn(Optional.of(userCoupon));
+
+            CouponProcessor processor = mock(CouponProcessor.class);
+            when(couponProcessorFactory.getProcessor(Coupon.TargetType.CART)).thenReturn(processor);
+
+            User user = mock(User.class);
+            when(user.getId()).thenReturn(3L);
+
+            Order order = mock(Order.class);
+
+            // act & assert
+            assertThatThrownBy(() -> couponService.applyCouponsToOrder(command, user, order))
+                    .isInstanceOf(CoreException.class)
+                    .extracting(ex -> ((CoreException) ex).getErrorType())
+                    .isEqualTo(ErrorType.BAD_REQUEST);
+
+            verify(couponProcessorFactory).getProcessor(Coupon.TargetType.CART);
+            verify(order, never()).updateFinalPrice(anyLong());
+        }
+
+        @Test
+        @DisplayName("[실패] 최소주문금액 미달 등으로 예외가 발생하면 중단한다")
+        void failure_applyCouponsToOrder_whenProcessorValidateFails() {
+            // arrange
+            OrderCommand.CreateOrder command = mock(OrderCommand.CreateOrder.class);
+            when(command.cartCouponId()).thenReturn(1L);
+
+            FixedAmountCoupon coupon = FixedAmountCoupon.builder()
+                    .couponCode("CART-AMOUNT-3000")
+                    .couponName("장바구니 3천원 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.valueOf(50000))
+                    .discountAmount(BigDecimal.valueOf(3000))
+                    .build();
+
+            UserCoupon userCoupon = UserCoupon.create(
+                    10L,
+                    coupon,
+                    UserCoupon.CouponStatus.ISSUED,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(1)
+            );
+            when(couponRepository.findByUserCouponId(1L)).thenReturn(Optional.of(userCoupon));
+
+            CouponProcessor processor = mock(CouponProcessor.class);
+            when(couponProcessorFactory.getProcessor(Coupon.TargetType.CART)).thenReturn(processor);
+
+            User user = mock(User.class);
+            when(user.getId()).thenReturn(10L);
+
+            Order order = mock(Order.class);
+            when(order.getPrice()).thenReturn(40000L);
+
+            doThrow(new CoreException(ErrorType.BAD_REQUEST, "최소 주문 금액을 충족하지 못했습니다."))
+                    .when(processor).validate(eq(userCoupon), eq(BigDecimal.valueOf(40000L)));
+
+            // act & assert
+            assertThatThrownBy(() -> couponService.applyCouponsToOrder(command, user, order))
+                    .isInstanceOf(CoreException.class)
+                    .hasMessageContaining("최소 주문 금액");
+
+            verify(couponRepository, never()).save(any(CouponUsage.class));
+        }
+
+        @Test
+        @DisplayName("[성공] 유효한 장바구니 쿠폰이면 할인 적용,사용내역 저장,최종결제금액 게산,쿠폰 사용 처리를 진행한다")
+        void success_applyCouponsToOrder_whenValidCartCoupon() {
+            // arrange
+            OrderCommand.CreateOrder command = mock(OrderCommand.CreateOrder.class);
+            when(command.cartCouponId()).thenReturn(1L);
+
+            FixedAmountCoupon coupon = FixedAmountCoupon.builder()
+                    .couponCode("CART-AMOUNT-3000")
+                    .couponName("장바구니 3천원 할인 쿠폰")
+                    .targetType(Coupon.TargetType.CART)
+                    .minOrderAmount(BigDecimal.ZERO)
+                    .discountAmount(BigDecimal.valueOf(3000))
+                    .build();
+
+            UserCoupon userCoupon = UserCoupon.create(
+                    10L,
+                    coupon,
+                    UserCoupon.CouponStatus.ISSUED,
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(1)
+            );
+            when(couponRepository.findByUserCouponId(1L)).thenReturn(Optional.of(userCoupon));
+
+            CouponProcessor processor = mock(CouponProcessor.class);
+            when(couponProcessorFactory.getProcessor(Coupon.TargetType.CART)).thenReturn(processor);
+
+            User user = mock(User.class);
+            when(user.getId()).thenReturn(10L);
+
+            Order order = mock(Order.class);
+            when(order.getPrice()).thenReturn(20000L);
+
+            // validate는 예외 없음
+            BigDecimal original = BigDecimal.valueOf(20000);
+            BigDecimal finalPrice = BigDecimal.valueOf(17000);
+            when(processor.apply(original, coupon)).thenReturn(finalPrice);
+
+            // act
+            couponService.applyCouponsToOrder(command, user, order);
+
+            // assert: 프로세서 호출
+            verify(processor).validate(eq(userCoupon), eq(original));
+            verify(processor).apply(eq(original), eq(coupon));
+
+            // 사용 내역 저장
+            verify(couponRepository).save(any(CouponUsage.class));
+
+            // 주문 업데이트
+            verify(order).updateFinalPrice(17000L);
+            verify(order).addCouponUsage(any(CouponUsage.class));
+
+            // 쿠폰 상태 변경
+            assertEquals(UserCoupon.CouponStatus.USED, userCoupon.getStatus());
+            assertNotNull(userCoupon.getUsedAt());
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/UserCouponEntityTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/UserCouponEntityTest.java
@@ -1,0 +1,166 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("UserCoupon 테스트")
+class UserCouponEntityTest {
+
+    @Test
+    @DisplayName("[성공] 정상적인 쿠폰일 경우 예외 없이 통과된다")
+    void success_checkAvailability_whenValidCoupon() {
+        var coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-1000")
+                .couponName("장바구니 천원 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(1000))
+                .build();
+
+        var now = LocalDateTime.now();
+        var userCoupon = UserCoupon.create(
+                1L,
+                coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                now,
+                now.plusDays(1)
+        );
+
+        assertDoesNotThrow(() -> userCoupon.checkAvailability(1L));
+    }
+
+    @Test
+    @DisplayName("[실패] 본인의 쿠폰이 아닌 경우 예외가 발생한다")
+    void failure_checkAvailability_whenUserIdDoesNotMatch() {
+        var coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-1000")
+                .couponName("장바구니 천원 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(1000))
+                .build();
+
+        var now = LocalDateTime.now();
+        var userCoupon = UserCoupon.create(
+                1L,
+                coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                now,
+                now.plusDays(1)
+        );
+
+        assertThatThrownBy(() -> userCoupon.checkAvailability(2L))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("본인의 쿠폰만 사용할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("[실패] 이미 사용된 쿠폰일 경우 예외가 발생한다")
+    void failure_checkAvailability_whenCouponAlreadyUsed() {
+        var coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-1000")
+                .couponName("장바구니 천원 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(1000))
+                .build();
+
+        var now = LocalDateTime.now();
+        var userCoupon = UserCoupon.create(
+                1L,
+                coupon,
+                UserCoupon.CouponStatus.USED,
+                now,
+                now.plusDays(1)
+        );
+
+        assertThatThrownBy(() -> userCoupon.checkAvailability(1L))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("사용할 수 없는 상태의 쿠폰입니다.");
+    }
+
+    @Test
+    @DisplayName("[실패] 만료된 쿠폰일 경우 예외가 발생한다")
+    void failure_checkAvailability_whenCouponExpired() {
+        var coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-1000")
+                .couponName("장바구니 천원 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(1000))
+                .build();
+
+        var now = LocalDateTime.now();
+        var userCoupon = UserCoupon.create(
+                1L,
+                coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                now,
+                now.minusDays(1)
+        );
+
+        assertThatThrownBy(() -> userCoupon.checkAvailability(1L))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("만료된 쿠폰입니다.");
+    }
+
+    @Test
+    @DisplayName("[성공] 쿠폰 사용 시 상태가 USED로 변경되고 usedAt이 설정된다")
+    void success_useCoupon_whenIssued() {
+        var coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-1000")
+                .couponName("장바구니 천원 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(1000))
+                .build();
+
+        var now = LocalDateTime.now();
+        var userCoupon = UserCoupon.create(
+                1L,
+                coupon,
+                UserCoupon.CouponStatus.ISSUED,
+                now,
+                now.plusDays(1)
+        );
+
+        userCoupon.use();
+
+        assertEquals(UserCoupon.CouponStatus.USED, userCoupon.getStatus());
+        assertNotNull(userCoupon.getUsedAt(), "사용일시가 설정되어야 합니다.");
+    }
+
+    @Test
+    @DisplayName("[실패] 취소(CANCELED) 상태의 쿠폰은 사용할 수 없다")
+    void failure_checkAvailability_whenCouponCanceled() {
+        var coupon = FixedAmountCoupon.builder()
+                .couponCode("CART-AMOUNT-1000")
+                .couponName("장바구니 천원 할인 쿠폰")
+                .targetType(Coupon.TargetType.CART)
+                .minOrderAmount(BigDecimal.ZERO)
+                .discountAmount(BigDecimal.valueOf(1000))
+                .build();
+
+        var now = LocalDateTime.now();
+        var userCoupon = UserCoupon.create(
+                1L,
+                coupon,
+                UserCoupon.CouponStatus.CANCELED,
+                now,
+                now.plusDays(1)
+        );
+
+        assertThatThrownBy(() -> userCoupon.checkAvailability(1L))
+                .isInstanceOf(CoreException.class)
+                .hasMessageContaining("사용할 수 없는 상태의 쿠폰입니다.");
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.product.ProductSkuService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+@SpringBootTest
+class OrderServiceIntegrationTest {
+
+    @Autowired
+    OrderService orderService;
+
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    ProductSkuService productSkuService;
+
+    @Autowired
+    DatabaseCleanUp databaseCleanUp;
+
+    Long userId;
+    Long productId;
+    Long skuId;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.create("user1", User.Gender.M, "사용자1","2020-02-20","xx@yy.zz",1000L);
+        user = userRepository.save(user);
+        userId = user.getId();
+
+        Product product = Product.create("맥북프로", Product.Status.ACTIVE,1L);
+        product = productRepository.saveProduct(product);
+        productId = product.getId();
+
+        ProductSku sku =  ProductSku.create(product, "macbookpro-gray-16",2000, 10, 0);
+        sku = productRepository.saveProductSkuAndFlush(sku);
+        skuId = sku.getId();
+    }
+
+    @AfterEach
+    void tearDown(){
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("[성공] 주문 상세 조회 — 아이템/금액 확인")
+    void success_getOrderDetail() {
+        Order order = Order.create(userId,0L);
+        order.addOrderItem(OrderItem.create(skuId, 3));
+        order.updatePrice(2000L * 3);
+        order = orderService.saveOrder(order);
+
+        Order found = orderService.getOrder(order.getId());
+
+        assertThat(found.getOrderItems()).hasSize(1);
+        assertThat(found.getPrice()).isEqualTo(6000L);
+    }
+
+    @Test
+    @DisplayName("[성공] 사용자 주문 목록 조회")
+    void success_getOrdersByUserId() {
+        Order o1 = Order.create(userId,0L);
+        o1.addOrderItem(OrderItem.create(skuId, 1));
+        o1.updatePrice(2000L);
+        orderService.saveOrder(o1);
+
+        Order o2 = Order.create(userId,0L);
+        o2.addOrderItem(OrderItem.create(skuId, 2));
+        o2.updatePrice(4000L);
+        orderService.saveOrder(o2);
+
+        List<Order> list = orderService.getOrdersByUserId(userId);
+        assertThat(list).hasSizeGreaterThanOrEqualTo(2);
+        assertThat(list.stream().map(Order::getUserId)).allMatch(id -> id.equals(userId));
+    }
+
+    @Test
+    @DisplayName("[실패] 없는 주문 조회 시 NOT_FOUND")
+    void failure_getOrder_whenNotFound() {
+        CoreException ex = assertThrows(CoreException.class,
+                () -> orderService.getOrder(999999L));
+        assertThat(ex.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[실패] 음수/0 금액으로 업데이트 시 BAD_REQUEST")
+    void failure_updatePrice_invalid() {
+        Order order = Order.create(userId,0L);
+        order.addOrderItem(OrderItem.create(skuId, 1));
+
+        CoreException zero = assertThrows(CoreException.class,
+                () -> order.updatePrice(0L));
+        assertThat(zero.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+        CoreException negative = assertThrows(CoreException.class,
+                () -> order.updatePrice(-100L));
+        assertThat(negative.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+
+}


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
- 쿠폰기능 설계 및 개발 
- 설계문서현행화(아및췬 안했다~)
- 통합테스트코드 작성
- 동시성 통합테스트 코드 작성 
- e2e 테스트 코드 작성 
-->

- 쿠폰기능 설계 및 개발 
   -  [feat : [쿠폰] 정액,정률 할이 반영 구현체 추가](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/a8733c109d8a06547728ef2bfe0bdcd1fe133569)
   - [feat : [쿠폰] 타입별 추상체, 구현체, 타입매핑 Factory 추가](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/eb8b1d63d02656cd86517eda0a4d7d7f9041f34e)
- 각 기능별 동시성 이슈에 대응하기위한 Lock 적용 및 동시성 통합테스트 코드 작성 
   - 주문 시 
      -  [fix : [동시성-쿠폰] 쿠폰차감 비관적 락 적용](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/5c8084c3d6492313f6863fa24a3773d407fb59da)
      -  [fix : [동시성-재고차감] 재고차감 낙관적 락 적용](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/baec33830b1095ef9e71e853a9e9dfb441dbb604)
   - 결제 시 
      -  [fix : [동시성-포인트] 포인트 차감 시 비관적 락 적용](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/4cda7d2f1691aab894663f8915833f285d97dabc)
      -  [test : [동시성-결제] 동시성 테스트](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/6b9e50577464319faa6a16c0f0467ffab4e2ff24)
  - 좋아요 
     -  [test : [좋아요] 좋아요 동시성 테스트](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/7f833b73d76cb9a6d14f6661a53ccb31b4b00c60)

## 💬 Review Points
<!--
    리뷰어가 더 효과적인 리뷰를 할 수 있도록 도와주는 부분입니다.
    (1) 리뷰어가 중점적으로 봐줬으면 하는 부분
    (2) 고민했던 설계 포인트나 로직
    (3) 리뷰어가 확인해줬으면 하는 테스트 케이스나 예외 상황
    (4) 기타 리뷰어가 참고해야 할 사항
- 쿠폰 서비스 코드가 너무 뚱뚱함..............아빠.,.곰은..뚱뚱해....
-->

- **CouponService 책임 분리 & 테스트 용이성**  [2e49e11](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/2e49e1106d7d1e9b04e077b949dbd32d791cf336)
   - ApplicationService는 오케스트레이션 역할만 맡기고, 쿠폰 관련 도메인 규칙(소유권 검증, 유효성 체크, 할인 계산, 사용 기록 등)은 쿠폰 영역에 두고자 했습니다.
   - 하지만 현재 CouponService에 이 모든 로직이 모여 있어 비대해진 상태입니다.
   - 그래서 책임을 분리하기위해  OwnershipPolicy, ValidityPolicy, Applicator 등 작은 정책 객체로 분리하는 방향을 고민 했으나 
   -  책임을 분리하기 위해 OwnershipPolicy, ValidityPolicy, Applicator 등 작은 정책 객체로 나누는 방안을 고민했지만, 로직이 지나치게 분산되는 느낌이 있어 엔티티 메서드로 옮기는 방안도 고려했습니다.
   - 이 부분에 대해 멘토님의 의견이 궁금합니다.

- **Processor / ProcessorFactory 설계 적정성** [a8733c1](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/a8733c109d8a06547728ef2bfe0bdcd1fe133569) ,  [eb8b1d6](https://github.com/Lexyyaa/Looper-Ecommerce/pull/5/commits/eb8b1d63d02656cd86517eda0a4d7d7f9041f34e)
   - 쿠폰 적용 로직을 확장 가능하게 만들기 위해 Processor + ProcessorFactory 구조를 도입했습니다.
   - ProcessorFactory는 단순히 조건에 따라 Processor를 선택하는 역할만 하고, 실제 로직은 각 Processor로 위임하는 형태로 구현했습니다.
   - 이런 역할 분리가 유지보수성과 응집도 측면에서 적절한지, 혹은 다른 방식(예: 공통 로직 일부를 Factory로 이동)이 더 나을지 피드백 부탁드립니다.
## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)


## 💻 Implementation Quest

> 주문 시, 재고/포인트/쿠폰의 정합성을 트랜잭션으로 보장하고, 동시성 이슈를 제어합니다.
> 

<aside>
🎯

**Must-Have (이번 주에 무조건 가져가야 좋을 것-**무조건 ****하세요**)**

- DB 트랜잭션
- Lock
- 동시성 테스트

**Nice-To-Have (부가적으로 가져가면 좋을 것-**시간이 ****허락하면 ****꼭 ****해보세요**)**

- 쿠폰 개념
- 미비한 기능 완성을 통한 API 마무리
</aside>

### **📦 추가 요구사항**

```json
{
  "items": [
    { "productId": 1, "quantity": 2 },
    { "productId": 3, "quantity": 1 }
  ],
  "couponId": 42 // 추가 스펙
}
```

- 주문 시에 쿠폰을 이용해 사용자가 소유한 쿠폰을 적용해 할인받을 수 있도록 합니다.
- 쿠폰은 **정액, 정률 쿠폰이 존재**하며 **재사용이 불가능**합니다.
- 존재하지 않거나 사용 불가능한 쿠폰으로 요청 시, 주문은 실패해야 합니다.

### 📋 과제 정보

- 주문 API에 트랜잭션을 적용하고, 재고/포인트/주문 도메인의 정합성을 보장합니다.
- 동시성 이슈(Lost Update)가 발생하지 않도록 낙관적 락 또는 비관적 락을 적용합니다.
- 주요 구현 대상은 Application Layer (혹은 OrderFacade 등)에서의 트랜잭션 처리입니다.
- 동시성 이슈가 발생할 수 있는 기능에 대한 테스트가 모두 성공해야 합니다.

**예시 (주문 처리 흐름)**

```kotlin
1. 주문 요청
2. "주문을 위한 처리" ( 순서 무관 )
	- 쿠폰 사용 및 차감 // 동시성 이슈 위험 구간
	- 상품 재고 확인 및 차감 // 동시성 이슈 위험 구간
	- 유저 포인트 확인 및 차감 // 동시성 이슈 위험 구간
5. 주문 엔티티 생성 및 저장
```

### 🚀 구현 보강

- 모든 API 가 요구사항 기반으로 동작해야 합니다.
- 미비한 구현에 대해 모두 완성해주세요



### **🐣 테스트 **

- [ ]  모든 테스트가 실패 없이 통과함
-->

### 🗞️ Coupon 도메인

- [x]  쿠폰은 사용자가 소유하고 있으며, 이미 사용된 쿠폰은 사용할 수 없어야 한다.
- [x]  쿠폰 종류는 정액 / 정률로 구분되며, 각 적용 로직을 구현하였다.
- [x]  각 발급된 쿠폰은 최대 한번만 사용될 수 있다.

### 🧾 **주문**

- [x]  주문 전체 흐름에 대해 원자성이 보장되어야 한다.
- [x]  사용 불가능하거나 존재하지 않는 쿠폰일 경우 주문은 실패해야 한다.
- [x]  재고가 존재하지 않거나 부족할 경우 주문은 실패해야 한다.
- [x]  주문 시 유저의 포인트 잔액이 부족할 경우 주문은 실패해야 한다
- [x]  쿠폰, 재고, 포인트 처리 등 하나라도 작업이 실패하면 모두 롤백처리되어야 한다.
- [x]  주문 성공 시, 모든 처리는 정상 반영되어야 한다.

### 🧪 동시성 테스트

- [x]  동일한 상품에 대해 여러명이 좋아요/싫어요를 요청해도, 상품의 좋아요 개수가 정상 반영되어야 한다.
- [x]  동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용되어야 한다.
- [x]  동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감되어야 한다.
- [x]  동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감되어야 한다.