### PR TITLE
[Round-06] 외부 PG모듈 연동 및 Resilience 적용

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -17,4 +17,20 @@ dependencies {
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
     testImplementation(testFixtures(project(":modules:redis")))
+
+
+    // feign
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
+    // Resilience4j
+    implementation(platform("io.github.resilience4j:resilience4j-bom:2.2.0"))
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+    implementation("io.github.resilience4j:resilience4j-circuitbreaker")
+    implementation("io.github.resilience4j:resilience4j-retry")
+    implementation("io.github.resilience4j:resilience4j-ratelimiter")
+    implementation("io.github.resilience4j:resilience4j-bulkhead")
+    implementation("io.github.resilience4j:resilience4j-timelimiter")
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
@@ -64,9 +64,10 @@ public class CardPaymentProcessor implements PaymentProcessor {
         Payment requested = null;
         if (res.txKey() != null) {
             requested = paymentService.bindTxKeyOnPending(payment, res.txKey());
+            return requested;
+        }else{
+            return payment;
         }
-
-        return requested;
     }
 
     @Retry(name = "pg-request")

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
@@ -36,11 +36,13 @@ public class CardPaymentProcessor implements PaymentProcessor {
         return Payment.Method.CARD;
     }
 
+    // request 적용
     @Retry(name = "pg-request")
-    @RateLimiter(name = "pg-request", fallbackMethod = "fallbackPending")
+    @RateLimiter(name = "pg-request")
     @CircuitBreaker(name = "pg-request", fallbackMethod = "fallbackPending")
     public Payment pay(User user, Order order,PaymentCommand.CreatePayment command) {
 
+        //결제 생성
         Payment payment = paymentService.createPending(
                 user.getId(),
                 order.getId(),

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/CardPaymentProcessor.java
@@ -1,0 +1,86 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.pg.PgClientAdapter;
+import com.loopers.domain.user.User;
+import com.loopers.domain.paymentgateway.PaymentGatewayRequest;
+import com.loopers.domain.paymentgateway.PaymentGatewayResponse;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CardPaymentProcessor implements PaymentProcessor {
+
+    private final PgClientAdapter pgClientAdapter;
+    private final PaymentService paymentService;
+
+    @Value("${pg.callback.base-url}")
+    private String pgCallbackBaseUrl;
+
+    @Value("${pg.callback.transaction-path}")
+    private String pgCallbackTransactionPath;
+
+    @Value("${pg.userid}")
+    private String pgUserId;
+
+    @Override
+    public Payment.Method getMethod() {
+        return Payment.Method.CARD;
+    }
+
+    @Retry(name = "pg-request")
+    @RateLimiter(name = "pg-request", fallbackMethod = "fallbackPending")
+    @CircuitBreaker(name = "pg-request", fallbackMethod = "fallbackPending")
+    public Payment pay(User user, Order order,PaymentCommand.CreatePayment command) {
+
+        Payment payment = paymentService.createPending(
+                user.getId(),
+                order.getId(),
+                order.getFinalPrice(),
+                command.method()
+        );
+
+        String callbackUrl = pgCallbackBaseUrl + pgCallbackTransactionPath;
+
+        PaymentGatewayResponse res = requestToPg(
+                payment.getId(),
+                new PaymentGatewayRequest(
+                        pgUserId + payment.getOrderId(),
+                        command.details().cardType(),
+                        command.details().cardNo(),
+                        payment.getAmount().toString(),
+                        callbackUrl,
+                        payment.getIdempotencyKey()
+                )
+        );
+        Payment requested = null;
+        if (res.txKey() != null) {
+            requested = paymentService.bindTxKeyOnPending(payment, res.txKey());
+        }
+
+        return requested;
+    }
+
+    @Retry(name = "pg-request")
+    @RateLimiter(name = "pg-request")
+    @CircuitBreaker(name = "pg-request", fallbackMethod = "fallbackPending")
+    protected PaymentGatewayResponse requestToPg(Long paymentId, PaymentGatewayRequest req) {
+        return pgClientAdapter.acceptPayment(req);
+    }
+
+    protected PaymentGatewayResponse fallbackPending(Long paymentId,
+                                                     PaymentGatewayRequest req,
+                                                     Throwable t) {
+        paymentService.failOnPgRequestError(paymentId, t);
+        return new PaymentGatewayResponse(null, null,
+                "PG request failed: " + (t != null ? t.getMessage() : null));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
@@ -1,0 +1,13 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.user.User;
+
+public interface  PaymentProcessor {
+
+    Payment.Method getMethod();
+
+    Payment pay(User user, Order order,PaymentCommand.CreatePayment command);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessorFactory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessorFactory.java
@@ -1,0 +1,21 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class PaymentProcessorFactory {
+
+    private final PointPaymentProcessor pointPaymentProcessor;
+    private final CardPaymentProcessor cardPaymentProcessor;
+
+    public PaymentProcessor of(Payment.Method method) {
+        return switch (method) {
+            case POINT -> pointPaymentProcessor;
+            case CARD -> cardPaymentProcessor;
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUsecase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUsecase.java
@@ -5,6 +5,7 @@ import com.loopers.domain.payment.PaymentInfo;
 
 public interface PaymentUsecase {
     PaymentInfo.CreatePayment createPayment(PaymentCommand.CreatePayment command);
+    void syncPayment(PaymentCommand.SyncPayment command);
+    void pollRecentPayments();
     PaymentInfo.CancelPayment cancelPayment(PaymentCommand.CancelPayment command);
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
@@ -36,7 +36,7 @@ public class PointPaymentProcessor implements PaymentProcessor {
     }
 
     @Override
-    @Transactional // 포인트결제는 리트라이는 하지않아도된다고판단ㄱㄱ
+    @Transactional
     public Payment pay(User user, Order order, PaymentCommand.CreatePayment command) {
         Payment saved = null;
 
@@ -63,39 +63,3 @@ public class PointPaymentProcessor implements PaymentProcessor {
         return saved;
     }
 }
-/**
- 중요!: PointPaymentProcessor에서 결제가 실패하면 RuntimeException을 던져야 합니다.
- 이렇게 하면 PaymentApplicationService의 메인 트랜잭션이 롤백되어,
- 함께 시도된 카드 결제 건(상태: PENDING)도 DB에 저장되지 않게 됩니다.
- 즉, 포인트가 부족하면 카드 결제 시도 자체를 막을 수 있습니다.
- */
-
-//@Embeddable
-//public record OrderNumber(String number) {
-//
-//    private static final String PREFIX = "29CART-";
-//
-//    public static OrderNumber initialize() {
-//        String uuid = UUID.randomUUID()
-//                .toString()
-//                .replace("-", "")
-//                .substring(0, 12)
-//                .toUpperCase();
-//        return new OrderNumber(PREFIX + uuid);
-//    }
-//}
-//
-//@Entity
-//@NoArgsConstructor(access = AccessLevel.PROTECTED)
-//public class User extends BaseEntity {
-//
-//    @NaturalId
-//    @AttributeOverride(
-//            name = "value",
-//            column = @Column(
-//                    name = "account_id",
-//                    nullable = false,
-//                    unique = true
-//            )
-//    )
-//    private AccountId accountId;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
@@ -1,0 +1,101 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.NaturalId;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PointPaymentProcessor implements PaymentProcessor {
+
+    private final UserService userService;
+    private final OrderService orderService;
+    private final PaymentService paymentService;
+
+    @Override
+    public Payment.Method getMethod() {
+        return Payment.Method.POINT;
+    }
+
+    @Override
+    @Transactional // 포인트결제는 리트라이는 하지않아도된다고판단ㄱㄱ
+    public Payment pay(User user, Order order, PaymentCommand.CreatePayment command) {
+        Payment saved = null;
+
+        //결제 생성
+        Payment payment = paymentService.createPending(
+                user.getId(),
+                order.getId(),
+                order.getFinalPrice(),
+                command.method()
+        );
+
+        try{
+            // 포인트 사용
+            userService.usePoint(user, order.getFinalPrice());
+            // 주문상태변경(주문완료)
+            orderService.confirmOrder(order);
+            // 결제상태변경(결제완료)
+            saved = paymentService.confirmPayment(payment);
+        }catch (CoreException e){
+            // 결제상태변경(결제실패)
+            saved = paymentService.cancelPayment(payment,e.getCustomMessage());
+        }
+
+        return saved;
+    }
+}
+/**
+ 중요!: PointPaymentProcessor에서 결제가 실패하면 RuntimeException을 던져야 합니다.
+ 이렇게 하면 PaymentApplicationService의 메인 트랜잭션이 롤백되어,
+ 함께 시도된 카드 결제 건(상태: PENDING)도 DB에 저장되지 않게 됩니다.
+ 즉, 포인트가 부족하면 카드 결제 시도 자체를 막을 수 있습니다.
+ */
+
+//@Embeddable
+//public record OrderNumber(String number) {
+//
+//    private static final String PREFIX = "29CART-";
+//
+//    public static OrderNumber initialize() {
+//        String uuid = UUID.randomUUID()
+//                .toString()
+//                .replace("-", "")
+//                .substring(0, 12)
+//                .toUpperCase();
+//        return new OrderNumber(PREFIX + uuid);
+//    }
+//}
+//
+//@Entity
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//public class User extends BaseEntity {
+//
+//    @NaturalId
+//    @AttributeOverride(
+//            name = "value",
+//            column = @Column(
+//                    name = "account_id",
+//                    nullable = false,
+//                    unique = true
+//            )
+//    )
+//    private AccountId accountId;

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PointPaymentProcessor.java
@@ -36,7 +36,7 @@ public class PointPaymentProcessor implements PaymentProcessor {
     }
 
     @Override
-    @Transactional
+    @Transactional // 별도의 재시도는 없음, DB Timeout 정도만 관리.
     public Payment pay(User user, Order order, PaymentCommand.CreatePayment command) {
         Payment saved = null;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -1,32 +1,39 @@
 package com.loopers.domain.payment;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.domain.paymentgateway.PaymentDetail;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "payment")
+@Table(name = "payment", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_payment_idempotency", columnNames = {"idempotencyKey"}),
+        @UniqueConstraint(name = "uk_payment_txKey",    columnNames = {"txKey"})
+})
 public class Payment extends BaseEntity {
-
-    public enum Method {
-        POINT, CREDIT
-    }
-
-    public enum Status {
-        PENDING, PAID, CANCELLED
-    }
 
     @Column(name = "user_id", nullable = false, updatable = false)
     private Long userId;
 
     @Column(name = "order_id", nullable = false, updatable = false)
     private Long orderId;
+
+    @Column(nullable = false)
+    private String txKey;
+
+    @Column(nullable = false, length = 64)
+    private String idempotencyKey;
+
+    @Column(length = 255)
+    private String failReason;
 
     @Column(nullable = false)
     private Long amount;
@@ -39,24 +46,67 @@ public class Payment extends BaseEntity {
     @Column(nullable = false)
     private Status status;
 
+    public enum Method {
+        POINT, CARD
+    }
+
+    public enum Status {
+        PENDING, REQUESTED, SUCCESS, FAILED, CANCELED ,
+    }
+
+    public void toRequested(String txKey) {
+        this.status = Status.REQUESTED;
+        this.txKey = txKey;
+    }
+
+    public void toSuccess() {
+        this.status = Status.SUCCESS;
+        this.updateDate();
+    }
+
+    public void toFail(String reason) {
+        this.status = Status.FAILED;
+        this.failReason = reason;
+        this.updateDate();
+    }
+
+    public void toCanceled() {
+        this.status = Status.CANCELED;
+        this.updateDate();
+    }
+
     public void pay(Long userId) {
-        if (this.status == Status.PAID) {
+        if (this.status == Status.SUCCESS) {
             throw new CoreException(ErrorType.CONFLICT, "이미 결제 완료 상태입니다.");
         }
-        if (this.status == Status.CANCELLED) {
+        if (this.status == Status.FAILED) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "잘못된 접근입니다.");
+        }
+        if (this.status == Status.CANCELED) {
             throw new CoreException(ErrorType.BAD_REQUEST, "취소된 건은 결제할 수 없습니다.");
         }
-        this.status = Status.PAID;
+        this.status = Status.SUCCESS;
+        this.updateDate();
     }
 
     public void cancel(Long userId) {
-        if (this.getStatus() == Payment.Status.CANCELLED) {
+        if (this.getStatus() == Payment.Status.CANCELED) {
             throw new CoreException(ErrorType.BAD_REQUEST,"이미 취소된 결제입니다.");
         }
-        if (this.status != Status.PAID) {
+        if (this.status != Status.SUCCESS) {
             throw new CoreException(ErrorType.BAD_REQUEST, "결제 완료 건만 취소할 수 있습니다.");
         }
-        this.status = Status.CANCELLED;
+        this.status = Status.CANCELED;
+        this.updateDate();
+    }
+
+    public static String generateIdemKey() {
+        String uuid = UUID.randomUUID()
+                .toString()
+                .replace("-", "")
+                .substring(0, 12)
+                .toUpperCase();
+        return uuid;
     }
 
     public static Payment create(Long userId, Long orderId, Long amount, Method method) {
@@ -66,6 +116,7 @@ public class Payment extends BaseEntity {
                 .amount(amount)
                 .method(method)
                 .status(Status.PENDING)
+                .idempotencyKey(generateIdemKey())
                 .build();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -26,7 +26,7 @@ public class Payment extends BaseEntity {
     @Column(name = "order_id", nullable = false, updatable = false)
     private Long orderId;
 
-    @Column(nullable = false)
+    @Column(nullable = true, updatable = false)
     private String txKey;
 
     @Column(nullable = false, length = 64)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
@@ -1,16 +1,75 @@
 package com.loopers.domain.payment;
 
+import com.loopers.interfaces.api.controller.payment.PaymentV1Request;
+import com.loopers.interfaces.api.controller.paymentgateway.PaymentGatewayV1Request;
+
+import java.math.BigDecimal;
+
 public class PaymentCommand {
     public record CreatePayment(
             String loginId,
             Long orderId,
             Long amount,
-            String method
+            Payment.Method method,
+            String idempotencyKey,
+            CardPaymentDetails details
+    ) {
+        public static CreatePayment create(
+                PaymentV1Request.CreatePayment request,
+                Long orderId
+        ) {
+            return new CreatePayment(
+                    request.loginId(),
+                    orderId,
+                    request.amount(),
+                    request.method(),
+                    request.idempotencyKey(),
+                    new CardPaymentDetails(
+                            request.details().cardType(),
+                            request.details().cardNo()
+                    )
+            );
+        }
+    }
+
+    //TODO. 카드결제 DTO 추후 추상체와 구현체 분리
+    public record CardPaymentDetails(
+            String cardType,
+            String cardNo
     ) {}
+
+    public record SyncPayment(
+            String transactionKey,
+            String orderId,
+            BigDecimal amount,
+            String status,
+            String reason
+    ){
+        public static SyncPayment create(PaymentGatewayV1Request.TransactionInfo request ) {
+            return new SyncPayment(
+                    request.transactionKey(),
+                    request.orderId(),
+                    request.amount(),
+                    request.status(),
+                    request.reason()
+            );
+        }
+
+        public static SyncPayment from(Payment payment) {
+            return new SyncPayment(
+                    payment.getTxKey(),
+                    payment.getOrderId().toString(),
+                    BigDecimal.valueOf(payment.getAmount()),
+                    payment.getStatus().toString(),
+                    payment.getFailReason()
+            );
+        }
+    }
 
     public record CancelPayment(
             String loginId,
             Long orderId,
             Long paymentId
     ) {}
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentCommand.java
@@ -11,7 +11,6 @@ public class PaymentCommand {
             Long orderId,
             Long amount,
             Payment.Method method,
-            String idempotencyKey,
             CardPaymentDetails details
     ) {
         public static CreatePayment create(
@@ -23,7 +22,6 @@ public class PaymentCommand {
                     orderId,
                     request.amount(),
                     request.method(),
-                    request.idempotencyKey(),
                     new CardPaymentDetails(
                             request.details().cardType(),
                             request.details().cardNo()

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentInfo.java
@@ -3,6 +3,7 @@ package com.loopers.domain.payment;
 import java.time.ZonedDateTime;
 
 public class PaymentInfo {
+
     public record CreatePayment(
             Long paymentId,
             Long userId,
@@ -10,7 +11,9 @@ public class PaymentInfo {
             Long amount,
             Payment.Method method,
             Payment.Status status,
-            ZonedDateTime createdAt
+            String idempotencyKey,
+            String transactionKey,
+            ZonedDateTime updatedAt
     ) {
         public static CreatePayment from(Payment payment) {
             return new CreatePayment(
@@ -20,7 +23,9 @@ public class PaymentInfo {
                     payment.getAmount(),
                     payment.getMethod(),
                     payment.getStatus(),
-                    payment.getCreatedAt()
+                    payment.getIdempotencyKey(),
+                    payment.getTxKey(),
+                    payment.getUpdatedAt()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,8 +1,12 @@
 package com.loopers.domain.payment;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentRepository {
     Payment save(Payment payment);
     Optional<Payment> findById(Long id);
+    Optional<Payment> findByTxKey(String txKey);
+    List<Payment> findRecentWaiting(LocalDateTime since,Payment.Status status);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -1,18 +1,44 @@
 package com.loopers.domain.payment;
 
+import com.loopers.domain.paymentgateway.PaymentDetail;
+import com.loopers.domain.pg.PgClientAdapter;
+import com.loopers.infrastructure.payment.PaymentJpaRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
+    private final PgClientAdapter pgClientAdapter;
+
+    @Transactional
+    public Payment createPending(Long userId, Long orderId, Long amount, Payment.Method method) {
+        Payment p = Payment.create(userId, orderId, amount, method);
+        return paymentRepository.save(p);
+    }
 
     public Payment save(Payment payment) {
         payment.pay(payment.getUserId());
+        return paymentRepository.save(payment);
+    }
+
+    public Payment confirmPayment(Payment payment) {
+        payment.toSuccess();
+        return paymentRepository.save(payment);
+    }
+
+    public Payment cancelPayment(Payment payment,String msg) {
+        payment.toFail(msg);
         return paymentRepository.save(payment);
     }
 
@@ -21,9 +47,46 @@ public class PaymentService {
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 결제입니다."));
     }
 
-    public Payment cancelPayment(Payment currPayment) {
-        currPayment.cancel(currPayment.getUserId());
-        Payment payment = paymentRepository.save(currPayment);
-        return payment;
+    @Transactional
+    public Payment bindTxKeyOnPending(Payment payment, String txKey) {
+            payment.toRequested(txKey);
+            Payment saved = paymentRepository.save(payment);
+            return saved;
     }
+
+    @Transactional(readOnly = true)
+    public Payment findByTxKey(String txKey) {
+        return paymentRepository.findByTxKey(txKey).orElseThrow(
+                () -> new CoreException(ErrorType.NOT_FOUND,"존재하지 않는 결제입니다.")
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public PaymentDetail getUniquePaymentDetail(Long orderId, String currentTxKey) {
+        Optional<PaymentDetail> unique = pgClientAdapter.findSingleSuccessPayment(String.valueOf(orderId));
+        if (unique.isPresent()) {
+            return unique.get();
+        }
+        return pgClientAdapter.getByTxKey(currentTxKey);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Payment> getRecentWaiting(LocalDateTime since) {
+        return paymentRepository.findRecentWaiting(since,Payment.Status.REQUESTED);
+    }
+
+    @Transactional
+    public void failOnPgRequestError(Long paymentId, Throwable t) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 결제입니다."));
+
+        if (payment.getStatus() == Payment.Status.SUCCESS || payment.getStatus() == Payment.Status.CANCELED) {
+            return;
+        }
+
+        payment.toFail("t.getMessage()");
+
+        paymentRepository.save(payment);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/paymentgateway/PaymentDetail.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/paymentgateway/PaymentDetail.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.paymentgateway;
+
+import com.loopers.domain.payment.Payment;
+
+public record PaymentDetail(
+        String transactionKey,
+        String orderId,
+        Long amount,
+        Payment.Status status,
+        String reason
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/paymentgateway/PaymentGatewayRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/paymentgateway/PaymentGatewayRequest.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.paymentgateway;
+
+public record PaymentGatewayRequest(
+        String orderId,
+        String cardType,
+        String cardNo,
+        String amount,
+        String callbackUrl,
+        String idempotencyKey) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/paymentgateway/PaymentGatewayResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/paymentgateway/PaymentGatewayResponse.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.paymentgateway;
+
+public record PaymentGatewayResponse(
+        String txKey,
+        String status,
+        String reason
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgClientAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/pg/PgClientAdapter.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.pg;
+
+import com.loopers.domain.paymentgateway.PaymentDetail;
+import com.loopers.domain.paymentgateway.PaymentGatewayRequest;
+import com.loopers.domain.paymentgateway.PaymentGatewayResponse;
+
+import java.util.Optional;
+
+public interface PgClientAdapter {
+    PaymentGatewayResponse acceptPayment(PaymentGatewayRequest req);
+    PaymentDetail getByTxKey(String txKey);
+    Optional<PaymentDetail> findSingleSuccessPayment(String orderId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -2,6 +2,30 @@ package com.loopers.infrastructure.payment;
 
 import com.loopers.domain.payment.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+
+    @Query("""
+        select p from Payment p
+        where p.txKey = :txKey
+    """)
+    Optional<Payment> findByTxKey(String txKey);
+
+    @Query("""
+        select p
+          from Payment p
+         where p.status = :status
+           and p.createdAt >= :since
+         order by p.createdAt asc
+    """)
+    List<Payment> findRecentWaiting(
+            @Param("since") LocalDateTime since,
+            @Param("status") Payment.Status status
+    );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.loopers.domain.payment.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -21,5 +23,15 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public Optional<Payment> findById(Long id) {
         return jpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Payment> findByTxKey(String txKey) {
+        return jpaRepository.findByTxKey(txKey);
+    }
+
+    @Override
+    public List<Payment> findRecentWaiting(LocalDateTime since,Payment.Status status) {
+        return jpaRepository.findRecentWaiting(since,status);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgClientAdapterImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgClientAdapterImpl.java
@@ -48,6 +48,7 @@ public class PgClientAdapterImpl implements PgClientAdapter {
         return PgFeignDto.PgPayDetail.toResponse(res);
     }
 
+    // read 적용
     @Override
     @Retry(name = "pg-read", fallbackMethod = "returnEmptyObject")
     public Optional<PaymentDetail> findSingleSuccessPayment(String orderId) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgClientAdapterImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgClientAdapterImpl.java
@@ -1,0 +1,86 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.paymentgateway.PaymentDetail;
+import com.loopers.domain.paymentgateway.PaymentGatewayRequest;
+import com.loopers.domain.paymentgateway.PaymentGatewayResponse;
+import com.loopers.domain.pg.PgClientAdapter;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PgClientAdapterImpl implements PgClientAdapter {
+
+    @Value("${pg.userid}")
+    private String pgUserId;
+
+    private final PgFeignClient client;
+
+    @Override
+    public PaymentGatewayResponse acceptPayment(PaymentGatewayRequest req) {
+        PgFeignDto.PgPayRequest body = new PgFeignDto.PgPayRequest(
+                req.orderId(),
+                req.cardType(),
+                req.cardNo(),
+                req.amount(),
+                req.callbackUrl(),
+                req.idempotencyKey()
+        );
+        PgFeignDto.PgPayResponse res = client.pay(pgUserId, body);
+
+        return PgFeignDto.PgPayResponse.toResponse(res);
+    }
+
+    @Override
+    public PaymentDetail getByTxKey(String txKey) {
+        PgFeignDto.PgPayDetail res = client.get(pgUserId, txKey);
+        return PgFeignDto.PgPayDetail.toResponse(res);
+    }
+
+    @Override
+    @Retry(name = "pg-read", fallbackMethod = "returnEmptyObject")
+    public Optional<PaymentDetail> findSingleSuccessPayment(String orderId) {
+        PgFeignDto.PgTxList list = client.byOrder(pgUserId, orderId);
+
+        List<PgFeignDto.PgTxList.Data.Tx> txs = (list != null && list.data() != null && list.data().transactions() != null)
+                ? list.data().transactions()
+                : List.<PgFeignDto.PgTxList.Data.Tx>of();
+
+        List<String> successTxKeys = txs.stream()
+                .filter(tx -> {
+                    String s = String.valueOf(tx.status());
+                    return s != null && s.equals(Payment.Status.SUCCESS.name());
+                })
+                .map(PgFeignDto.PgTxList.Data.Tx::transactionKey)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (successTxKeys.isEmpty()) {
+            return Optional.empty();
+        }
+        if (successTxKeys.size() > 1) {
+            throw new CoreException(ErrorType.CONFLICT,
+                    "중복 성공처리된 건 : orderId=" + orderId);
+        }
+
+        String txKey = successTxKeys.get(0);
+        return Optional.of(getByTxKey(txKey));
+    }
+
+    protected Optional<PaymentDetail> returnEmptyObject(String orderId, Throwable t) {
+        log.warn("pg-read 실패 orderId : {} ", orderId, t.getMessage());
+        return Optional.empty();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignClient.java
@@ -1,0 +1,18 @@
+package com.loopers.infrastructure.pg;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+
+@FeignClient(name="pgClient", url="${pg.base-url}", configuration= PgFeignConfig.class)
+public interface PgFeignClient {
+
+    @PostMapping("/api/v1/payments")
+    PgFeignDto.PgPayResponse pay(@RequestHeader("X-USER-ID") String pgUserId, @RequestBody PgFeignDto.PgPayRequest body);
+
+    @GetMapping("/api/v1/payments/{txKey}")
+    PgFeignDto.PgPayDetail get(@RequestHeader("X-USER-ID") String pgUserId, @PathVariable String txKey);
+
+    @GetMapping("/api/v1/payments")
+    PgFeignDto.PgTxList byOrder(@RequestHeader("X-USER-ID") String pgUserId, @RequestParam String orderId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignConfig.java
@@ -1,0 +1,97 @@
+package com.loopers.infrastructure.pg;
+
+import feign.Request;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class PgFeignConfig {
+
+    @Bean
+    Request.Options options() {
+        return new Request.Options(200, TimeUnit.MILLISECONDS, 1000, TimeUnit.MILLISECONDS, true);
+    }
+
+    @Bean
+    public ErrorDecoder pgErrorDecoder() {
+        return (methodKey, response) -> {
+            int status = response.status();
+
+            // 짧은 오류 메시지용 바디 추출(최대 200자)
+            String body = "";
+            try {
+                if (response.body() != null) {
+                    String s = new String(response.body().asInputStream().readAllBytes(), StandardCharsets.UTF_8);
+                    body = s.length() > 200 ? s.substring(0, 200) + "…" : s;
+                }
+            } catch (IOException ignored) {}
+
+            // 408/429/5xx → 재시도 대상(RetryableException)로 표준화
+            if (status == 408 || status == 429 || status >= 500) {
+                // (옵션) Retry-After 헤더가 "초" 숫자면 힌트로 반영
+                Date retryAfter = null;
+                if (response.headers() != null) {
+                    Collection<String> vals = response.headers().get("Retry-After");
+                    if (vals != null && !vals.isEmpty()) {
+                        String v = vals.iterator().next();
+                        if (!v.isBlank() && v.chars().allMatch(Character::isDigit)) {
+                            retryAfter = new Date(System.currentTimeMillis() + Long.parseLong(v) * 1000);
+                        }
+                    }
+                }
+                Request req = response.request();
+                Request.HttpMethod method = (req != null) ? req.httpMethod() : null;
+                String msg = "PG " + status + (body.isBlank() ? "" : (" " + body));
+                return new RetryableException(status, msg, method, retryAfter, req);
+            }
+
+            // 그 외(주로 4xx)는 기본 Feign 예외 → 재시도 제외(Resilience4j에서 ignore)
+            return feign.FeignException.errorStatus(methodKey, response);
+        };
+    }
+
+
+//    @Bean
+//    public ErrorDecoder pgErrorDecoder() {
+//        return (methodKey, response) -> {
+//            int status = response.status();
+//
+//            String body = "";
+//            try {
+//                if (response.body() != null) {
+//                    body = new String(response.body().asInputStream().readAllBytes(), StandardCharsets.UTF_8);
+//                    if (body.length() > 500) body = body.substring(0, 500) + " …";
+//                }
+//            } catch (IOException ignored) { }
+//
+//            if (status == 408 || status == 429 || status >= 500) {
+//                Date retryAfter = null;
+//                List<String> vals = response.headers() != null ? response.headers().get("Retry-After") : null;
+//                if (vals != null && !vals.isEmpty()) {
+//                    String v = vals.get(0);
+//                    if (v != null && v.matches("\\d+")) {
+//                        retryAfter = new Date(System.currentTimeMillis() + Long.parseLong(v) * 1000L);
+//                    }
+//                }
+//                Request req = response.request();
+//                return new RetryableException(
+//                        status,
+//                        "PG " + status + (body.isEmpty() ? "" : " " + body),
+//                        req != null ? req.httpMethod() : null,
+//                        retryAfter,
+//                        req
+//                );
+//            }
+//
+//            return FeignException.errorStatus(methodKey, response);
+//        };
+//    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignDto.java
@@ -6,14 +6,14 @@ import com.loopers.domain.paymentgateway.PaymentGatewayResponse;
 
 public class PgFeignDto {
 
-    record PgPayRequest(String orderId, String cardType, String cardNo,
+    public record PgPayRequest(String orderId, String cardType, String cardNo,
                         String amount, String callbackUrl, String idempotencyKey) {}
 
-    record PgPayResponse(Meta meta, Data data) {
+    public record PgPayResponse(Meta meta, Data data) {
 
-        record Meta(String result) {}
+        public record Meta(String result) {}
 
-        record Data(String transactionKey, String status, String reason) {
+        public record Data(String transactionKey, String status, String reason) {
         }
         public static PaymentGatewayResponse toResponse(PgPayResponse res) {
             if (res == null) return new PaymentGatewayResponse(null, null, null);
@@ -26,11 +26,11 @@ public class PgFeignDto {
         }
     }
 
-    record PgPayDetail(Meta meta, Data data) {
+    public record PgPayDetail(Meta meta, Data data) {
 
-        record Meta(String result) {}
+        public record Meta(String result) {}
 
-        record Data(
+        public record Data(
                 String transactionKey,
                 String orderId,
                 String cardType,

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignDto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/pg/PgFeignDto.java
@@ -1,0 +1,64 @@
+package com.loopers.infrastructure.pg;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.paymentgateway.PaymentDetail;
+import com.loopers.domain.paymentgateway.PaymentGatewayResponse;
+
+public class PgFeignDto {
+
+    record PgPayRequest(String orderId, String cardType, String cardNo,
+                        String amount, String callbackUrl, String idempotencyKey) {}
+
+    record PgPayResponse(Meta meta, Data data) {
+
+        record Meta(String result) {}
+
+        record Data(String transactionKey, String status, String reason) {
+        }
+        public static PaymentGatewayResponse toResponse(PgPayResponse res) {
+            if (res == null) return new PaymentGatewayResponse(null, null, null);
+            Meta m = res.meta();
+            Data d = res.data();
+            if (d == null) {
+                return new PaymentGatewayResponse(null, null, (m != null ? m.result() : null));
+            }
+            return new PaymentGatewayResponse(d.transactionKey(), d.status(), d.reason());
+        }
+    }
+
+    record PgPayDetail(Meta meta, Data data) {
+
+        record Meta(String result) {}
+
+        record Data(
+                String transactionKey,
+                String orderId,
+                String cardType,
+                String cardNo,
+                Long amount,
+                Payment.Status status,
+                String reason
+        ) {}
+        public static PaymentDetail toResponse(PgPayDetail res) {
+            if (res == null) return new PaymentDetail(null, null, null, null, null);
+            Meta m = res.meta();
+            Data d = res.data();
+            if (d == null) {
+                return new PaymentDetail(null, null, null, null, (m != null ? m.result() : null));
+            }
+            return new PaymentDetail(
+                    d.transactionKey(),
+                    d.orderId(),
+                    d.amount(),
+                    d.status(),
+                    d.reason()
+            );
+        }
+    }
+    record PgTxList(Meta meta, Data data) {
+        record Meta(String result) {}
+        record Data(String orderId, java.util.List<Tx> transactions) {
+            record Tx(String transactionKey, Payment.Status status, String reason) {}
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentController.java
@@ -4,32 +4,29 @@ import com.loopers.application.payment.PaymentUsecase;
 import com.loopers.domain.payment.PaymentCommand;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/orders/{orderId}/payments")
+@RequestMapping("/api/v1/payments")
 public class PaymentController implements PaymentV1ApiSpec {
 
     private final PaymentUsecase paymentUsecase;
 
-    @PostMapping
+    @PostMapping("/{orderId}")
     public ApiResponse<PaymentV1Response.CreatePayment> createPayment(
             @PathVariable Long orderId,
             @RequestBody PaymentV1Request.CreatePayment request
     ) {
-        PaymentCommand.CreatePayment command = new PaymentCommand.CreatePayment(
-                request.loginId(),
-                orderId,
-                request.amount(),
-                request.method()
-        );
+        PaymentCommand.CreatePayment command = PaymentCommand.CreatePayment.create(request, orderId);
 
         var paymentInfo = paymentUsecase.createPayment(command);
         return ApiResponse.success(PaymentV1Response.CreatePayment.from(paymentInfo));
     }
 
-    @DeleteMapping("/{paymentId}")
+    @DeleteMapping("/{orderId}")
     public ApiResponse<PaymentV1Response.CancelPayment> cancelPayment(
             @PathVariable Long orderId,
             @PathVariable Long paymentId,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1ApiSpec.java
@@ -7,9 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "결제", description = "결제 생성 및 취소 관련 API")
 public interface PaymentV1ApiSpec {
@@ -18,7 +16,7 @@ public interface PaymentV1ApiSpec {
             summary = "결제 생성",
             description = "특정 주문에 대한 결제 정보를 생성합니다."
     )
-    @PostMapping("/api/v1/orders/{orderId}/payments")
+
     ApiResponse<PaymentV1Response.CreatePayment> createPayment(
             @Parameter(name = "orderId", description = "결제할 주문의 고유 ID")
             @PathVariable Long orderId,
@@ -33,7 +31,6 @@ public interface PaymentV1ApiSpec {
             summary = "결제 취소",
             description = "특정 결제 건을 취소합니다. 결제 취소 시 해당 주문의 상태가 변경될 수 있습니다."
     )
-    @DeleteMapping("/api/v1/orders/{orderId}/payments/{paymentId}")
     ApiResponse<PaymentV1Response.CancelPayment> cancelPayment(
             @Parameter(name = "orderId", description = "취소할 결제 건이 속한 주문의 고유 ID")
             @PathVariable Long orderId,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Request.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Request.java
@@ -1,11 +1,34 @@
 package com.loopers.interfaces.api.controller.payment;
 
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+
+import java.util.regex.Pattern;
+
 public class PaymentV1Request {
+
     public record CreatePayment(
             String loginId,
             Long amount,
-            String method
+            Payment.Method method,
+            String idempotencyKey,
+            CardPaymentDetails details
     ) {}
+
+    //TODO. 카드결제 DTO 추후 추상체와 구현체 분리
+    public record CardPaymentDetails(
+            String cardType,
+            String cardNo
+    ) {
+        private static final Pattern REGEX_CARD_NO = Pattern.compile("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$");
+        public CardPaymentDetails {
+            if (cardNo == null || !REGEX_CARD_NO.matcher(cardNo).matches()) {
+                throw new CoreException(ErrorType.BAD_REQUEST,"카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.");
+            }
+        }
+    }
 
     public record CancelPayment(
             String loginId

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Response.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/payment/PaymentV1Response.java
@@ -13,7 +13,9 @@ public class PaymentV1Response {
             Long amount,
             Payment.Method method,
             Payment.Status status,
-            ZonedDateTime createdAt
+            String idempotencyKey,
+            String transactionKey,
+            ZonedDateTime updatedAt
     ) {
         public static CreatePayment from(PaymentInfo.CreatePayment info) {
             return new CreatePayment(
@@ -23,7 +25,9 @@ public class PaymentV1Response {
                     info.amount(),
                     info.method(),
                     info.status(),
-                    info.createdAt()
+                    info.idempotencyKey(),
+                    info.transactionKey(),
+                    info.updatedAt()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/paymentgateway/PaymentGatewayController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/paymentgateway/PaymentGatewayController.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.controller.paymentgateway;
+
+import com.loopers.application.payment.PaymentUsecase;
+import com.loopers.domain.payment.PaymentCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/pg")
+public class PaymentGatewayController implements PaymentGatewayV1ApiSpec {
+
+    private final PaymentUsecase paymentUsecase;
+
+    @PostMapping("/callback")
+    public void getPgCallback(@RequestBody PaymentGatewayV1Request.TransactionInfo request) {
+        PaymentCommand.SyncPayment command = PaymentCommand.SyncPayment.create(request);
+        paymentUsecase.syncPayment(command);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/paymentgateway/PaymentGatewayV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/paymentgateway/PaymentGatewayV1ApiSpec.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.controller.paymentgateway;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "PG연동", description = "PG연동 관련 API")
+public interface PaymentGatewayV1ApiSpec {
+
+    @Operation(
+            summary = "PG Callback",
+            description = "결제요청 후 처리가 완료되면 호출하는 콜백 API"
+    )
+    void getPgCallback(@RequestBody PaymentGatewayV1Request.TransactionInfo transactionInfo) ;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/paymentgateway/PaymentGatewayV1Request.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/controller/paymentgateway/PaymentGatewayV1Request.java
@@ -1,0 +1,16 @@
+package com.loopers.interfaces.api.controller.paymentgateway;
+
+import java.math.BigDecimal;
+
+public class PaymentGatewayV1Request {
+    public record TransactionInfo(
+            String transactionKey,
+            String orderId,
+            String cardType,
+            String cardNo,
+            BigDecimal amount,
+            String status,
+            String reason
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/payment/PaymentPollingScheduler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/scheduler/payment/PaymentPollingScheduler.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.scheduler.payment;
+
+import com.loopers.application.payment.PaymentUsecase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentPollingScheduler {
+
+    private static final long FIXED_DELAY_MS = 180_000L;
+
+    private final PaymentUsecase paymentUsecase;
+
+    @Scheduled(fixedDelay = FIXED_DELAY_MS)
+    public void run() {
+        try {
+            paymentUsecase.pollRecentPayments();
+        } catch (Exception e) {
+            log.error("Payment poll batch error", e.getMessage());
+        }
+    }
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -35,6 +35,12 @@ spring:
     activate:
       on-profile: local, test
 
+pg:
+  userid: songcommerce
+  callback:
+    base-url: http://localhost:8080/api/v1
+    transaction-path: /pg/callback
+
 ---
 spring:
   config:
@@ -73,3 +79,60 @@ datasource:
     replicas:
       - host: redis-readonly
         port: 6379
+
+
+feign:
+  client:
+    config:
+      pgClient:
+        connectTimeout: 500
+        readTimeout: 1000
+
+resilience4j:
+  retry:
+    instances:
+      pg-request: # 결제요청(쓰기)
+        max-attempts: 3
+        wait-duration: 200ms
+        enable-exponential-backoff: true
+        exponential-backoff-multiplier: 2.0
+        enable-randomized-wait: true
+        fail-after-max-attempts: true
+        retry-exceptions:
+          - feign.RetryableException
+          - java.net.SocketTimeoutException
+        ignore-exceptions:
+          - feign.FeignException
+
+      pg-read: # 상태조회(읽기
+        max-attempts: 2
+        wait-duration: 150ms
+        enable-exponential-backoff: true
+        exponential-backoff-multiplier: 2.0
+        enable-randomized-wait: true
+        fail-after-max-attempts: true
+        retry-exceptions:
+          - feign.RetryableException
+          - java.net.SocketTimeoutException
+        ignore-exceptions:
+          - feign.FeignException
+
+  circuitbreaker:
+    instances:
+      pg-request:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 20
+        failure-rate-threshold: 50
+        slow-call-duration-threshold: 800ms
+        slow-call-rate-threshold: 60
+        permitted-number-of-calls-in-half-open-state: 3
+        minimum-number-of-calls: 10
+        wait-duration-in-open-state: 5s
+
+  ratelimiter:
+    instances:
+      pg-request:
+        limit-for-period: 20
+        limit-refresh-period: 1s
+        timeout-duration: 100ms
+

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/CardPaymentProcessorTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/CardPaymentProcessorTest.java
@@ -1,0 +1,130 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderItem;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentCommand;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.paymentgateway.PaymentGatewayResponse;
+import com.loopers.domain.pg.PgClientAdapter;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductSku;
+import com.loopers.domain.user.User;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = {"pg.base-url=http://localhost:8080"})
+class CardPaymentProcessorTest {
+
+    @Autowired
+    private CardPaymentProcessor cardPaymentProcessor;
+
+    @Autowired
+    private PaymentService paymentService;
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @MockBean
+    private PgClientAdapter pgClientAdapter;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private User user;
+    private Order order;
+    private PaymentCommand.CreatePayment command;
+
+    @BeforeEach
+    void setUp() {
+        user = User.create("user1", User.Gender.M, "사용자1","2020-02-20","xx@yy.zz",1000L);
+        user = userRepository.save(user);
+
+        Product product = Product.create("맥북프로", Product.Status.ACTIVE,1L);
+        product = productRepository.saveProduct(product);
+        ProductSku sku = ProductSku.create(product, "macbookpro-gray-16",3000, 10, 0);
+        sku = productRepository.saveProductSkuAndFlush(sku);
+
+        order = Order.create(user.getId(),0L);
+        order.addOrderItem(OrderItem.create(sku.getId(), 2));
+        order.updatePrice(3000L * 2);
+        order = orderService.saveOrder(order);
+
+        command = new PaymentCommand.CreatePayment(
+                user.getLoginId(),
+                order.getId(),
+                order.getPrice(),
+                Payment.Method.CARD,
+                new PaymentCommand.CardPaymentDetails("SAMSUNG", "1234-5678-xxxx-xxxx")
+        );
+    }
+
+    @AfterEach
+    void tearDown(){
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("[성공] PG사 결제 요청 성공")
+    void success_pg_request() {
+        String transactionKey = UUID.randomUUID().toString();
+        PaymentGatewayResponse successResponse = new PaymentGatewayResponse(transactionKey, "SUCCESS", null);
+        when(pgClientAdapter.acceptPayment(any())).thenReturn(successResponse);
+
+        Payment result = cardPaymentProcessor.pay(user, order, command);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTxKey()).isEqualTo(transactionKey);
+        assertThat(result.getStatus()).isEqualTo(Payment.Status.REQUESTED);
+    }
+
+    @Test
+    @DisplayName("[실패] PG사 결제 요청 실패")
+    void failure_pg_request() {
+        PaymentGatewayResponse failedResponse = new PaymentGatewayResponse(null, "FAILED", "한도 초과");
+        when(pgClientAdapter.acceptPayment(any())).thenReturn(failedResponse);
+
+        Payment result = cardPaymentProcessor.pay(user, order, command);
+
+        Payment paymentInDb = paymentService.getPayment(result.getId());
+        assertThat(paymentInDb.getStatus()).isEqualTo(Payment.Status.PENDING);
+        assertThat(paymentInDb.getFailReason()).isNull();
+    }
+
+    @Test
+    @DisplayName("[실패] PG사 통신 오류로 fallback 실행")
+    void failure_pg_request_network_error() {
+        when(pgClientAdapter.acceptPayment(any())).thenThrow(new RuntimeException("PG사 연결 시간 초과"));
+
+        try {
+            Payment result = cardPaymentProcessor.pay(user, order, command);
+            Payment paymentInDb = paymentService.getPayment(result.getId());
+            assertThat(paymentInDb).isNotNull();
+            assertThat(paymentInDb.getStatus()).isEqualTo(Payment.Status.PENDING);
+            assertThat(paymentInDb.getFailReason()).contains("PG request failed");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("PG사 연결 시간 초과");
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentProcessorFactoryTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentProcessorFactoryTest.java
@@ -1,0 +1,39 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.Payment;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("PaymentProcessorFactory 단위 테스트 ")
+public class PaymentProcessorFactoryTest {
+
+    @Test
+    @DisplayName("[성공] CARD 타입에 대해 CardPaymentProcessor 를 반환한다")
+    void success_getProcessor_whenCard() {
+        CardPaymentProcessor card = mock(CardPaymentProcessor.class);
+        PointPaymentProcessor point = mock(PointPaymentProcessor.class);
+
+        PaymentProcessorFactory factory = new PaymentProcessorFactory(point, card);
+
+        PaymentProcessor selected = factory.of(Payment.Method.CARD);
+
+        assertThat(selected).isSameAs(card);
+    }
+
+    @Test
+    @DisplayName("[성공] POINT 타입에 대해 PointPaymentProcessor 를 반환한다")
+    void success_getProcessor_whenPoint() {
+        CardPaymentProcessor card = mock(CardPaymentProcessor.class);
+        PointPaymentProcessor point = mock(PointPaymentProcessor.class);
+
+        PaymentProcessorFactory factory = new PaymentProcessorFactory(point, card);
+
+        PaymentProcessor selected = factory.of(Payment.Method.POINT);
+
+        assertThat(selected).isSameAs(point);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -34,7 +37,7 @@ class PaymentTest {
             p.pay(p.getUserId());
             p.cancel(p.getUserId());
 
-            assertThat(p.getStatus()).isEqualTo(Payment.Status.CANCELLED);
+            assertThat(p.getStatus()).isEqualTo(Payment.Status.CANCELED);
         }
 
         @Test
@@ -48,5 +51,17 @@ class PaymentTest {
                     () -> p.cancel(p.getUserId()));
             assertThat(ex.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
         }
+    }
+
+    @Test
+    @DisplayName("generateIdemKey(): 1000개 생성해도 중복 없고 12자리 대문자/숫자")
+    void success_generateIdemKey() {
+        Set<String> set = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            String key = Payment.generateIdemKey();
+            assertThat(key).matches("[A-Z0-9]{12}");
+            set.add(key);
+        }
+        assertThat(set).hasSize(1000);
     }
 }

--- a/modules/jpa/src/main/java/com/loopers/domain/BaseEntity.java
+++ b/modules/jpa/src/main/java/com/loopers/domain/BaseEntity.java
@@ -62,4 +62,10 @@ public abstract class BaseEntity {
             this.deletedAt = ZonedDateTime.now();
         }
     }
+
+    public void updateDate() {
+        if (this.updatedAt == null) {
+            this.updatedAt = ZonedDateTime.now();
+        }
+    }
 }


### PR DESCRIPTION
## 📌 Summary
- 카드 결제 기능 추가
- Feign 클라이언트를 통한 PG 연동
- PG 콜백 전용 컨트롤러를 일반 사용자 API와 분리
- 카드 결제 테스트는 모킹 기반으로 작성

## 💬 Review Points
 **콜백 컨트롤러 분리 여부**
- PG 쪽에서 오는 콜백(webhook)은 일반 사용자 API와 요구사항(보안 검증, 멱등성, 재시도 처리 등)이 다르다고 판단해 별도의 컨트롤러로 분리했습니다.
- 다만, 한편으로는 어쨌든 같은 결제 도메인에 속하기 때문에 기존 결제 컨트롤러와 함께 두는 게 더 자연스러울 수도 있겠다는 생각도 들었습니다. 이 부분은 보통 어떻게 관리하시는지 궁금합니다.

**인프라 전용 DTO**
- PG와 통신하기 위해 인프라 전용 DTO를 만들었는데, 처음 다뤄보는 패턴이라 조금 어색했습니다.
- 네이밍을 단순히 Request / Response로 붙이자니 인터페이스 레이어 DTO랑 헷갈리고, 
- 그렇다고 도메인 계층에 DTO를 몰아두고 그대로 쓰자니 DIP에 어긋나는 것 같아 고민이 됩니다. 
- 이런 경우 보통 어떤 네이밍이나 위치를 권장하시는지 의견을 듣고 싶습니다.

## ✅ Checklist

### **⚡ PG 연동 대응**   ([b1eb175](https://github.com/Lexyyaa/Looper-Ecommerce/pull/11/commits/b1eb1752a56327fa2fb4aade8f3ab17acedf1e07) , [ec09c88](https://github.com/Lexyyaa/Looper-Ecommerce/pull/11/commits/ec09c880a405d05a2a474d60100e1ad860edfbdf) , [cc8cd8e](https://github.com/Lexyyaa/Looper-Ecommerce/pull/11/commits/cc8cd8e65284cd2070380b0c5913a665bd20fc8b))

- [x]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [x]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [x]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [x]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계** ( [3f3882f](https://github.com/Lexyyaa/Looper-Ecommerce/pull/11/commits/3f3882fc7d9e9f05ddfde29c0c1b1f082f70412a))

- [x]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [x]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [x]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [x]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.
